### PR TITLE
ignoring events with delta non zero improves performance a lot

### DIFF
--- a/Scripts/Editor/NodeEditorGUI.cs
+++ b/Scripts/Editor/NodeEditorGUI.cs
@@ -277,6 +277,9 @@ namespace XNodeEditor {
 
         private void DrawNodes() {
             Event e = Event.current;
+            if (e.delta != Vector2.zero) {
+                return;
+            }
             if (e.type == EventType.Layout) {
                 selectionCache = new List<UnityEngine.Object>(Selection.objects);
             }


### PR DESCRIPTION
specially on macOS (it recevies a lot of unnecessary EventType.MouseMove events