### PR TITLE
From .ToString() to .Name

### DIFF
--- a/Scripts/Editor/NodeEditorAction.cs
+++ b/Scripts/Editor/NodeEditorAction.cs
@@ -301,7 +301,7 @@ namespace XNodeEditor {
         public void CreateNode(Type type, Vector2 position) {
             XNode.Node node = graph.AddNode(type);
             node.position = position;
-            node.name = UnityEditor.ObjectNames.NicifyVariableName(type.ToString());
+            node.name = UnityEditor.ObjectNames.NicifyVariableName(type.Name);
             AssetDatabase.AddObjectToAsset(node, graph);
             if (NodeEditorPreferences.GetSettings().autoSave) AssetDatabase.SaveAssets();
             Repaint();


### PR DESCRIPTION
Changed from .ToString() to .Name that omits the namespace from the name.