### PR TITLE
Fixes the undo bug, and hopefully the inconsistent values in inspector/node

### DIFF
--- a/Scripts/Editor/NodeEditor.cs
+++ b/Scripts/Editor/NodeEditor.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEditor;
@@ -43,6 +43,10 @@ namespace XNodeEditor {
 
         /// <summary> Draws standard field editors for all public fields </summary>
         public virtual void OnBodyGUI() {
+            // Unity specifically requires this to save/update any serial object.
+            // serializedObject.Update(); must go at the start of an inspector gui, and
+            // serializedObject.ApplyModifiedProperties(); goes at the end.
+            serializedObject.Update();
             string[] excludes = { "m_Script", "graph", "position", "ports" };
             portPositions = new Dictionary<XNode.NodePort, Vector2>();
 
@@ -54,6 +58,7 @@ namespace XNodeEditor {
                 if (excludes.Contains(iterator.name)) continue;
                 NodeEditorGUILayout.PropertyField(iterator, true);
             }
+            serializedObject.ApplyModifiedProperties();
         }
 
         public virtual int GetWidth() {
@@ -93,4 +98,5 @@ namespace XNodeEditor {
             }
         }
     }
+
 }


### PR DESCRIPTION
I initially found out about this through
https://docs.unity3d.com/ScriptReference/Editor.html 
specifically these two comments:

```csharp
// Update the serializedProperty - always do this in the beginning of OnInspectorGUI.
        serializedObject.Update ();
...
// Apply changes to the serializedProperty - always do this in the end of OnInspectorGUI.
        serializedObject.ApplyModifiedProperties ();
```

I'm assuming, although I don't know for sure, that since OnBodyGUI displays the serialize objects in the custom inspector, that it must follow the same rules as well. Either way these lines of code solve for me the glitch: pressing undo while typing and getting a disconnect between the node and the inspector.