### PR TITLE
OSX does not dispatch SoftDelete 

### DIFF
--- a/Scripts/Editor/NodeEditorAction.cs
+++ b/Scripts/Editor/NodeEditorAction.cs
@@ -279,6 +279,7 @@ namespace XNodeEditor {
                     break;
                 case EventType.ValidateCommand:
                     if (e.commandName == "SoftDelete") RemoveSelectedNodes();
+                    else if (SystemInfo.operatingSystemFamily == OperatingSystemFamily.MacOSX && e.commandName == "Delete") RemoveSelectedNodes();
                     else if (e.commandName == "Duplicate") DublicateSelectedNodes();
                     Repaint();
                     break;


### PR DESCRIPTION
(tested on MBP no external keyboard)

Did not change the SoftDelete test due to not knowing how a MBP with full size external keyboard would behave.