### PR TITLE
Clear edit-mode when reselecting node while renaming node

### DIFF
--- a/Scripts/Editor/NodeEditor.cs
+++ b/Scripts/Editor/NodeEditor.cs
@@ -13,19 +13,28 @@ namespace XNodeEditor {
         /// <summary> Fires every whenever a node was modified through the editor </summary>
         public static Action<XNode.Node> onUpdateNode;
         public static Dictionary<XNode.NodePort, Vector2> portPositions;
-        public static int renaming;
+        public int renaming;
 
         public virtual void OnHeaderGUI() {
             string title = target.name;
-            if (renaming != 0 && Selection.Contains(target)) {
-                int controlID = EditorGUIUtility.GetControlID(FocusType.Keyboard) + 1;
-                if (renaming == 1) {
-                    EditorGUIUtility.keyboardControl = controlID;
-                    EditorGUIUtility.editingTextField = true;
-                    renaming = 2;
+            if (renaming != 0) { 
+                if (Selection.Contains(target)) {
+                    int controlID = EditorGUIUtility.GetControlID(FocusType.Keyboard) + 1;
+                    if (renaming == 1) {
+                        EditorGUIUtility.keyboardControl = controlID;
+                        EditorGUIUtility.editingTextField = true;
+                        renaming = 2;
+                    }
+                    target.name = EditorGUILayout.TextField(target.name, NodeEditorResources.styles.nodeHeader, GUILayout.Height(30));
+                    if (!EditorGUIUtility.editingTextField) {
+                        Debug.Log("Finish renaming");
+                        Rename(target.name);
+                        renaming = 0;
+                    }
                 }
-                target.name = EditorGUILayout.TextField(target.name, NodeEditorResources.styles.nodeHeader, GUILayout.Height(30));
-                if (!EditorGUIUtility.editingTextField) {
+                else {
+                    // Selection changed, so stop renaming.
+                    GUILayout.Label(title, NodeEditorResources.styles.nodeHeader, GUILayout.Height(30));
                     Rename(target.name);
                     renaming = 0;
                 }


### PR DESCRIPTION
When renaming a node in the graph editor, selecting a different node does not end editing, it simply transfers the editor field over to the currently selected node, including the old node's name. Finishing the edit by hitting enter seems to rename the originally selected node, but it looks and behaves weird.

This PR fixes that by (a) making the edit-state non-static, so that it is bound to the editor that initiated the editing and (b) checking that the edited node actually stays selected during the whole rename process. If the selection changes, the rename will be applied. 