### PR TITLE
Allow to trigger renames via F2 key

### DIFF
--- a/Scripts/Editor/NodeEditor.cs
+++ b/Scripts/Editor/NodeEditor.cs
@@ -31,7 +31,18 @@ namespace XNodeEditor {
                 }
             } else {
                 GUILayout.Label(title, NodeEditorResources.styles.nodeHeader, GUILayout.Height(30));
+                if (HasFocus() && IsRenameKeyPressed()) {
+                    InitiateRename();
+                }
             }
+        }
+
+        bool HasFocus() {
+            return Selection.activeObject == this.target;
+        }
+
+        bool IsRenameKeyPressed() {
+            return (Event.current != null && Event.current.isKey && Event.current.keyCode == KeyCode.F2);
         }
 
         /// <summary> Draws standard field editors for all public fields </summary>


### PR DESCRIPTION
A quick addition that allows to rename nodes by hitting F2 (same key as in the Hierarchy and Project browser). Using the context menu gets tiring pretty quickly. 