### PR TITLE
Cloned nodes have old graph as reference when OnEnable/Init is called

### DIFF
--- a/Scripts/Node.cs
+++ b/Scripts/Node.cs
@@ -62,8 +62,8 @@ namespace XNode {
 
         protected void OnEnable() {
             UpdateStaticPorts();
-            Init();
-            if (graph != null && !graph.CopyInProgress) {
+
+            if (graph != null && !graph.copyInProgress) {
                 OnEnableOverride();
             }
         }
@@ -80,11 +80,12 @@ namespace XNode {
         /// <summary>
         /// Initialize node. Called on creation and after clone in the correct order.  
         /// </summary>
-        // Implementation note: This method is called after a node has been instantiated, and also
-        // called directly when cloning a full graph. This simply calls Init(), which cannot be
-        // called from outside, as it is protected, not public, and making it public would break
-        // existing code.
         public virtual void OnEnableOverride() {
+            // Implementation note: This method is called after a node has been instantiated, and also
+            // called directly when cloning a full graph. This simply calls Init(), which cannot be
+            // called from outside, as it is protected, not public, and making it public would break
+            // existing code.
+
             Init();
         }
 

--- a/Scripts/Node.cs
+++ b/Scripts/Node.cs
@@ -63,6 +63,9 @@ namespace XNode {
         protected void OnEnable() {
             UpdateStaticPorts();
             Init();
+            if (graph != null && !graph.CopyInProgress) {
+                OnEnableOverride();
+            }
         }
 
         /// <summary> Update static ports to reflect class fields. This happens automatically on enable. </summary>
@@ -72,6 +75,18 @@ namespace XNode {
 
         /// <summary> Initialize node. Called on creation. </summary>
         protected virtual void Init() { }
+
+
+        /// <summary>
+        /// Initialize node. Called on creation and after clone in the correct order.  
+        /// </summary>
+        // Implementation note: This method is called after a node has been instantiated, and also
+        // called directly when cloning a full graph. This simply calls Init(), which cannot be
+        // called from outside, as it is protected, not public, and making it public would break
+        // existing code.
+        public virtual void OnEnableOverride() {
+            Init();
+        }
 
         /// <summary> Checks all connections for invalid references, and removes them. </summary>
         public void VerifyConnections() {


### PR DESCRIPTION
This fix changes the clone behaviour so that nodes have the correct graph reference when OnEnable/Init is called during a clone operation. OnEnable is called automatically during the Instantiate call. However, at that point the node still has a reference to the old graph, so any code that tries to work with connected nodes is using the wrong graph instance. 

The fix delays the Init() call until the whole graph has been cloned and the nodes have been reconnected to the cloned instances. 

As Init() is a protected member that cannot be called from outside, I had to redirect the call through a public "OnEnableOverride" method that is callable by the graph instance - changing Init() to public would break existing code that overrides that method.