### PR TITLE
Fix/error on duplicate

### DIFF
--- a/Scripts/Editor/NodeEditorAction.cs
+++ b/Scripts/Editor/NodeEditorAction.cs
@@ -278,9 +278,21 @@ namespace XNodeEditor {
                     }
                     break;
                 case EventType.ValidateCommand:
-                    if (e.commandName == "SoftDelete") RemoveSelectedNodes();
-                    else if (SystemInfo.operatingSystemFamily == OperatingSystemFamily.MacOSX && e.commandName == "Delete") RemoveSelectedNodes();
-                    else if (e.commandName == "Duplicate") DublicateSelectedNodes();
+                case EventType.ExecuteCommand:
+                    if (e.commandName == "SoftDelete") {
+                        if (e.type == EventType.ExecuteCommand) RemoveSelectedNodes();
+                        e.Use();
+                    }
+                    else if (SystemInfo.operatingSystemFamily == OperatingSystemFamily.MacOSX && e.commandName == "Delete")
+                    {
+                        if (e.type == EventType.ExecuteCommand) RemoveSelectedNodes();
+                        e.Use();
+                    }
+                    else if (e.commandName == "Duplicate")
+                    {
+                        if (e.type == EventType.ExecuteCommand) DuplicateSelectedNodes();
+                        e.Use();
+                    }
                     Repaint();
                     break;
                 case EventType.Ignore:
@@ -357,8 +369,8 @@ namespace XNodeEditor {
             }
         }
 
-        /// <summary> Dublicate selected nodes and select the dublicates </summary>
-        public void DublicateSelectedNodes() {
+        /// <summary> Aligns selected nodes to either left/right/top/bottom edge of nodes </summary>
+        public void DuplicateSelectedNodes() {
             UnityEngine.Object[] newNodes = new UnityEngine.Object[Selection.objects.Length];
             Dictionary<XNode.Node, XNode.Node> substitutes = new Dictionary<XNode.Node, XNode.Node>();
             for (int i = 0; i < Selection.objects.Length; i++) {

--- a/Scripts/Editor/NodeEditorAction.cs
+++ b/Scripts/Editor/NodeEditorAction.cs
@@ -282,14 +282,10 @@ namespace XNodeEditor {
                     if (e.commandName == "SoftDelete") {
                         if (e.type == EventType.ExecuteCommand) RemoveSelectedNodes();
                         e.Use();
-                    }
-                    else if (SystemInfo.operatingSystemFamily == OperatingSystemFamily.MacOSX && e.commandName == "Delete")
-                    {
+                    } else if (SystemInfo.operatingSystemFamily == OperatingSystemFamily.MacOSX && e.commandName == "Delete") {
                         if (e.type == EventType.ExecuteCommand) RemoveSelectedNodes();
                         e.Use();
-                    }
-                    else if (e.commandName == "Duplicate")
-                    {
+                    } else if (e.commandName == "Duplicate") {
                         if (e.type == EventType.ExecuteCommand) DuplicateSelectedNodes();
                         e.Use();
                     }

--- a/Scripts/Editor/NodeEditorAction.cs
+++ b/Scripts/Editor/NodeEditorAction.cs
@@ -365,7 +365,7 @@ namespace XNodeEditor {
             }
         }
 
-        /// <summary> Aligns selected nodes to either left/right/top/bottom edge of nodes </summary>
+        /// <summary> Duplicate selected nodes and select the duplicates </summary>
         public void DuplicateSelectedNodes() {
             UnityEngine.Object[] newNodes = new UnityEngine.Object[Selection.objects.Length];
             Dictionary<XNode.Node, XNode.Node> substitutes = new Dictionary<XNode.Node, XNode.Node>();

--- a/Scripts/Editor/NodeEditorGUI.cs
+++ b/Scripts/Editor/NodeEditorGUI.cs
@@ -126,7 +126,7 @@ namespace XNodeEditor {
                 contextMenu.AddItem(new GUIContent("Rename"), false, RenameSelectedNode);
             }
 
-            contextMenu.AddItem(new GUIContent("Duplicate"), false, DublicateSelectedNodes);
+            contextMenu.AddItem(new GUIContent("Duplicate"), false, DuplicateSelectedNodes);
             contextMenu.AddItem(new GUIContent("Remove"), false, RemoveSelectedNodes);
 
             // If only one node is selected


### PR DESCRIPTION
 Pressing CTRL+D (duplicate) threw editorgui exception "Getting control 0s position in a group with only 3 controls when doing ValidateCommand".

comparing to https://github.com/Unity-Technologies/UnityCsReference/blob/master/Editor/Mono/SceneHierarchyWindow.cs : row 211, the proper use of the event was not made.

also fixed spelling of Dublicate to Duplicate.