### PR TITLE
Move context menu methods from NodeEditorWindow to appropriate editor scripts so they can be overwritten

### DIFF
--- a/Scripts/Editor/NodeEditor.cs
+++ b/Scripts/Editor/NodeEditor.cs
@@ -81,6 +81,27 @@ namespace XNodeEditor {
             return NodeEditorResources.styles.nodeBody;
         }
 
+        /// <summary> Show right-click context menu for selected nodes </summary>
+        public virtual GenericMenu GetContextMenu() {
+            GenericMenu contextMenu = new GenericMenu();
+            // If only one node is selected
+            if (Selection.objects.Length == 1 && Selection.activeObject is XNode.Node) {
+                XNode.Node node = Selection.activeObject as XNode.Node;
+                contextMenu.AddItem(new GUIContent("Move To Top"), false, () => NodeEditorWindow.current.MoveNodeToTop(node));
+                contextMenu.AddItem(new GUIContent("Rename"), false, NodeEditorWindow.current.RenameSelectedNode);
+            }
+
+            contextMenu.AddItem(new GUIContent("Duplicate"), false, NodeEditorWindow.current.DuplicateSelectedNodes);
+            contextMenu.AddItem(new GUIContent("Remove"), false, NodeEditorWindow.current.RemoveSelectedNodes);
+
+            // If only one node is selected
+            if (Selection.objects.Length == 1 && Selection.activeObject is XNode.Node) {
+                XNode.Node node = Selection.activeObject as XNode.Node;
+                NodeEditorWindow.AddCustomContextMenuItems(contextMenu, node);
+            }
+            return contextMenu;
+        }
+
         public void InitiateRename() {
             renaming = 1;
         }

--- a/Scripts/Editor/NodeEditor.cs
+++ b/Scripts/Editor/NodeEditor.cs
@@ -81,25 +81,24 @@ namespace XNodeEditor {
             return NodeEditorResources.styles.nodeBody;
         }
 
-        /// <summary> Show right-click context menu for selected nodes </summary>
-        public virtual GenericMenu GetContextMenu() {
-            GenericMenu contextMenu = new GenericMenu();
-            // If only one node is selected
+        /// <summary> Add items for the context menu when right-clicking this node. Override to add custom menu items. </summary>
+        public virtual void AddContextMenuItems(GenericMenu menu) {
+            // Actions if only one node is selected
             if (Selection.objects.Length == 1 && Selection.activeObject is XNode.Node) {
                 XNode.Node node = Selection.activeObject as XNode.Node;
-                contextMenu.AddItem(new GUIContent("Move To Top"), false, () => NodeEditorWindow.current.MoveNodeToTop(node));
-                contextMenu.AddItem(new GUIContent("Rename"), false, NodeEditorWindow.current.RenameSelectedNode);
+                menu.AddItem(new GUIContent("Move To Top"), false, () => NodeEditorWindow.current.MoveNodeToTop(node));
+                menu.AddItem(new GUIContent("Rename"), false, NodeEditorWindow.current.RenameSelectedNode);
             }
 
-            contextMenu.AddItem(new GUIContent("Duplicate"), false, NodeEditorWindow.current.DuplicateSelectedNodes);
-            contextMenu.AddItem(new GUIContent("Remove"), false, NodeEditorWindow.current.RemoveSelectedNodes);
+            // Add actions to any number of selected nodes
+            menu.AddItem(new GUIContent("Duplicate"), false, NodeEditorWindow.current.DuplicateSelectedNodes);
+            menu.AddItem(new GUIContent("Remove"), false, NodeEditorWindow.current.RemoveSelectedNodes);
 
-            // If only one node is selected
+            // Custom sctions if only one node is selected
             if (Selection.objects.Length == 1 && Selection.activeObject is XNode.Node) {
                 XNode.Node node = Selection.activeObject as XNode.Node;
-                NodeEditorWindow.AddCustomContextMenuItems(contextMenu, node);
+                NodeEditorWindow.AddCustomContextMenuItems(menu, node);
             }
-            return contextMenu;
         }
 
         public void InitiateRename() {

--- a/Scripts/Editor/NodeEditorAction.cs
+++ b/Scripts/Editor/NodeEditorAction.cs
@@ -260,7 +260,7 @@ namespace XNodeEditor {
                                 ShowPortContextMenu(hoveredPort);
                             } else if (IsHoveringNode && IsHoveringTitle(hoveredNode)) {
                                 if (!Selection.Contains(hoveredNode)) SelectNode(hoveredNode, false);
-                                ShowNodeContextMenu();
+                                NodeEditor.GetEditor(hoveredNode).GetContextMenu().DropDown(new Rect(Event.current.mousePosition, Vector2.zero));
                             } else if (!IsHoveringNode) {
                                 ShowGraphContextMenu();
                             }

--- a/Scripts/Editor/NodeEditorAction.cs
+++ b/Scripts/Editor/NodeEditorAction.cs
@@ -260,7 +260,9 @@ namespace XNodeEditor {
                                 ShowPortContextMenu(hoveredPort);
                             } else if (IsHoveringNode && IsHoveringTitle(hoveredNode)) {
                                 if (!Selection.Contains(hoveredNode)) SelectNode(hoveredNode, false);
-                                NodeEditor.GetEditor(hoveredNode).GetContextMenu().DropDown(new Rect(Event.current.mousePosition, Vector2.zero));
+                                GenericMenu menu = new GenericMenu();
+                                NodeEditor.GetEditor(hoveredNode).AddContextMenuItems(menu);
+                                menu.DropDown(new Rect(Event.current.mousePosition, Vector2.zero));
                             } else if (!IsHoveringNode) {
                                 ShowGraphContextMenu();
                             }

--- a/Scripts/Editor/NodeEditorAction.cs
+++ b/Scripts/Editor/NodeEditorAction.cs
@@ -264,7 +264,9 @@ namespace XNodeEditor {
                                 NodeEditor.GetEditor(hoveredNode).AddContextMenuItems(menu);
                                 menu.DropDown(new Rect(Event.current.mousePosition, Vector2.zero));
                             } else if (!IsHoveringNode) {
-                                ShowGraphContextMenu();
+                                GenericMenu menu = new GenericMenu();
+                                graphEditor.AddContextMenuItems(menu);
+                                menu.DropDown(new Rect(Event.current.mousePosition, Vector2.zero));
                             }
                         }
                         isPanning = false;
@@ -323,15 +325,6 @@ namespace XNodeEditor {
         public void Home() {
             zoom = 2;
             panOffset = Vector2.zero;
-        }
-
-        public void CreateNode(Type type, Vector2 position) {
-            XNode.Node node = graph.AddNode(type);
-            node.position = position;
-            node.name = UnityEditor.ObjectNames.NicifyVariableName(type.Name);
-            AssetDatabase.AddObjectToAsset(node, graph);
-            if (NodeEditorPreferences.GetSettings().autoSave) AssetDatabase.SaveAssets();
-            Repaint();
         }
 
         /// <summary> Remove nodes in the graph in Selection.objects</summary>

--- a/Scripts/Editor/NodeEditorGUI.cs
+++ b/Scripts/Editor/NodeEditorGUI.cs
@@ -116,28 +116,6 @@ namespace XNodeEditor {
             if (NodeEditorPreferences.GetSettings().autoSave) AssetDatabase.SaveAssets();
         }
 
-        /// <summary> Show right-click context menu for selected nodes </summary>
-        public void ShowNodeContextMenu() {
-            GenericMenu contextMenu = new GenericMenu();
-            // If only one node is selected
-            if (Selection.objects.Length == 1 && Selection.activeObject is XNode.Node) {
-                XNode.Node node = Selection.activeObject as XNode.Node;
-                contextMenu.AddItem(new GUIContent("Move To Top"), false, () => MoveNodeToTop(node));
-                contextMenu.AddItem(new GUIContent("Rename"), false, RenameSelectedNode);
-            }
-
-            contextMenu.AddItem(new GUIContent("Duplicate"), false, DuplicateSelectedNodes);
-            contextMenu.AddItem(new GUIContent("Remove"), false, RemoveSelectedNodes);
-
-            // If only one node is selected
-            if (Selection.objects.Length == 1 && Selection.activeObject is XNode.Node) {
-                XNode.Node node = Selection.activeObject as XNode.Node;
-                AddCustomContextMenuItems(contextMenu, node);
-            }
-
-            contextMenu.DropDown(new Rect(Event.current.mousePosition, Vector2.zero));
-        }
-
         /// <summary> Show right-click context menu for current graph </summary>
         void ShowGraphContextMenu() {
             GenericMenu contextMenu = new GenericMenu();
@@ -157,17 +135,6 @@ namespace XNodeEditor {
             contextMenu.AddItem(new GUIContent("Preferences"), false, () => OpenPreferences());
             AddCustomContextMenuItems(contextMenu, graph);
             contextMenu.DropDown(new Rect(Event.current.mousePosition, Vector2.zero));
-        }
-
-        void AddCustomContextMenuItems(GenericMenu contextMenu, object obj) {
-            KeyValuePair<ContextMenu, System.Reflection.MethodInfo>[] items = GetContextMenuMethods(obj);
-            if (items.Length != 0) {
-                contextMenu.AddSeparator("");
-                for (int i = 0; i < items.Length; i++) {
-                    KeyValuePair<ContextMenu, System.Reflection.MethodInfo> kvp = items[i];
-                    contextMenu.AddItem(new GUIContent(kvp.Key.menuItem), false, () => kvp.Value.Invoke(obj, null));
-                }
-            }
         }
 
         /// <summary> Draw a bezier from startpoint to endpoint, both in grid coordinates </summary>

--- a/Scripts/Editor/NodeEditorGUI.cs
+++ b/Scripts/Editor/NodeEditorGUI.cs
@@ -116,27 +116,6 @@ namespace XNodeEditor {
             if (NodeEditorPreferences.GetSettings().autoSave) AssetDatabase.SaveAssets();
         }
 
-        /// <summary> Show right-click context menu for current graph </summary>
-        void ShowGraphContextMenu() {
-            GenericMenu contextMenu = new GenericMenu();
-            Vector2 pos = WindowToGridPosition(Event.current.mousePosition);
-            for (int i = 0; i < nodeTypes.Length; i++) {
-                Type type = nodeTypes[i];
-
-                //Get node context menu path
-                string path = graphEditor.GetNodeMenuName(type);
-                if (string.IsNullOrEmpty(path)) continue;
-
-                contextMenu.AddItem(new GUIContent(path), false, () => {
-                    CreateNode(type, pos);
-                });
-            }
-            contextMenu.AddSeparator("");
-            contextMenu.AddItem(new GUIContent("Preferences"), false, () => OpenPreferences());
-            AddCustomContextMenuItems(contextMenu, graph);
-            contextMenu.DropDown(new Rect(Event.current.mousePosition, Vector2.zero));
-        }
-
         /// <summary> Draw a bezier from startpoint to endpoint, both in grid coordinates </summary>
         public void DrawConnection(Vector2 startPoint, Vector2 endPoint, Color col) {
             startPoint = GridToWindowPosition(startPoint);

--- a/Scripts/Editor/NodeEditorReflection.cs
+++ b/Scripts/Editor/NodeEditorReflection.cs
@@ -71,6 +71,17 @@ namespace XNodeEditor {
             return types.ToArray();
         }
 
+        public static void AddCustomContextMenuItems(GenericMenu contextMenu, object obj) {
+            KeyValuePair<ContextMenu, System.Reflection.MethodInfo>[] items = GetContextMenuMethods(obj);
+            if (items.Length != 0) {
+                contextMenu.AddSeparator("");
+                for (int i = 0; i < items.Length; i++) {
+                    KeyValuePair<ContextMenu, System.Reflection.MethodInfo> kvp = items[i];
+                    contextMenu.AddItem(new GUIContent(kvp.Key.menuItem), false, () => kvp.Value.Invoke(obj, null));
+                }
+            }
+        }
+
         public static KeyValuePair<ContextMenu, MethodInfo>[] GetContextMenuMethods(object obj) {
             Type type = obj.GetType();
             MethodInfo[] methods = type.GetMethods(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);

--- a/Scripts/Editor/NodeGraphEditor.cs
+++ b/Scripts/Editor/NodeGraphEditor.cs
@@ -38,8 +38,37 @@ namespace XNodeEditor {
                 return ObjectNames.NicifyVariableName(type.ToString().Replace('.', '/'));
         }
 
+        /// <summary> Add items for the context menu when right-clicking this node. Override to add custom menu items. </summary>
+        public virtual void AddContextMenuItems(GenericMenu menu) {
+            Vector2 pos = NodeEditorWindow.current.WindowToGridPosition(Event.current.mousePosition);
+            for (int i = 0; i < NodeEditorWindow.nodeTypes.Length; i++) {
+                Type type = NodeEditorWindow.nodeTypes[i];
+
+                //Get node context menu path
+                string path = GetNodeMenuName(type);
+                if (string.IsNullOrEmpty(path)) continue;
+
+                menu.AddItem(new GUIContent(path), false, () => {
+                    CreateNode(type, pos);
+                });
+            }
+            menu.AddSeparator("");
+            menu.AddItem(new GUIContent("Preferences"), false, () => NodeEditorWindow.OpenPreferences());
+            NodeEditorWindow.AddCustomContextMenuItems(menu, target);
+        }
+
         public virtual Color GetTypeColor(Type type) {
             return NodeEditorPreferences.GetTypeColor(type);
+        }
+
+        /// <summary> Create a node and save it in the graph asset </summary>
+        public virtual void CreateNode(Type type, Vector2 position) {
+            XNode.Node node = target.AddNode(type);
+            node.position = position;
+            node.name = UnityEditor.ObjectNames.NicifyVariableName(type.Name);
+            AssetDatabase.AddObjectToAsset(node, target);
+            if (NodeEditorPreferences.GetSettings().autoSave) AssetDatabase.SaveAssets();
+            NodeEditorWindow.RepaintAll();
         }
 
         /// <summary> Creates a copy of the original node in the graph </summary>


### PR DESCRIPTION
Moved `NodeEditorWindow.ShowNodeContextMenu` to `NodeEditor.AddContextMenuItems`
Moved `NodeEditorWindow.ShowGraphContextMenu ` to `NodeGraphEditor.AddContextMenuItems`
Moved `NodeEditorWindow.CreateNode` to `NodeGraphEditor.CreateNode`