### PR TITLE
Changed from string to Type in TypeColors Dictionary

### DIFF
--- a/Scripts/Editor/NodeEditorPreferences.cs
+++ b/Scripts/Editor/NodeEditorPreferences.cs
@@ -12,7 +12,7 @@ namespace XNodeEditor {
         /// <summary> The last key we checked. This should be the one we modify </summary>
         private static string lastKey = "xNode.Settings";
 
-        private static Dictionary<string, Color> typeColors = new Dictionary<string, Color>();
+        private static Dictionary<Type, Color> typeColors = new Dictionary<Type, Color>();
         private static Dictionary<string, Settings> settings = new Dictionary<string, Settings>();
 
         [System.Serializable]
@@ -134,15 +134,16 @@ namespace XNodeEditor {
             EditorGUILayout.LabelField("Types", EditorStyles.boldLabel);
 
             //Display type colors. Save them if they are edited by the user
-            List<string> typeColorKeys = new List<string>(typeColors.Keys);
-            foreach (string typeColorKey in typeColorKeys) {
-                Color col = typeColors[typeColorKey];
+            foreach (var typeColor in typeColors) {
+				Type type = typeColor.Key;
+				string typeColorKey = NodeEditorUtilities.PrettyName(type);
+				Color col = typeColor.Value;
                 EditorGUI.BeginChangeCheck();
                 EditorGUILayout.BeginHorizontal();
                 col = EditorGUILayout.ColorField(typeColorKey, col);
                 EditorGUILayout.EndHorizontal();
                 if (EditorGUI.EndChangeCheck()) {
-                    typeColors[typeColorKey] = col;
+                    typeColors[type] = col;
                     if (settings.typeColors.ContainsKey(typeColorKey)) settings.typeColors[typeColorKey] = col;
                     else settings.typeColors.Add(typeColorKey, col);
                     SavePrefs(typeColorKey, settings);
@@ -165,7 +166,7 @@ namespace XNodeEditor {
         public static void ResetPrefs() {
             if (EditorPrefs.HasKey(lastKey)) EditorPrefs.DeleteKey(lastKey);
             if (settings.ContainsKey(lastKey)) settings.Remove(lastKey);
-            typeColors = new Dictionary<string, Color>();
+            typeColors = new Dictionary<Type, Color>();
             VerifyLoaded();
             NodeEditorWindow.RepaintAll();
         }
@@ -184,19 +185,21 @@ namespace XNodeEditor {
         public static Color GetTypeColor(System.Type type) {
             VerifyLoaded();
             if (type == null) return Color.gray;
-            string typeName = type.PrettyName();
-            if (!typeColors.ContainsKey(typeName)) {
-                if (settings[lastKey].typeColors.ContainsKey(typeName)) typeColors.Add(typeName, settings[lastKey].typeColors[typeName]);
+			Color col;
+            if (!typeColors.TryGetValue(type, out col)) {
+				string typeName = type.PrettyName();
+                if (settings[lastKey].typeColors.ContainsKey(typeName)) typeColors.Add(type, settings[lastKey].typeColors[typeName]);
                 else {
 #if UNITY_5_4_OR_NEWER
                     UnityEngine.Random.InitState(typeName.GetHashCode());
 #else
                     UnityEngine.Random.seed = typeName.GetHashCode();
 #endif
-                    typeColors.Add(typeName, new Color(UnityEngine.Random.value, UnityEngine.Random.value, UnityEngine.Random.value));
+					col = new Color(UnityEngine.Random.value, UnityEngine.Random.value, UnityEngine.Random.value);
+					typeColors.Add(type, col);
                 }
             }
-            return typeColors[typeName];
+            return col;
         }
     }
 }


### PR DESCRIPTION
Changed so Dictionary now takes Type as key.

Reduces use of PrettyName, PrettyName generates garbage and can be slow.
Also changed to TryGetValue instead of ContainsKey in GetTypeColor().