### PR TITLE
Add qAI to "Projects using xNode"

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,4 @@ Feel free to also leave suggestions/requests in the [issues](https://github.com/
 Projects using xNode:
 * [Graphmesh](https://github.com/Siccity/Graphmesh "Go to github page")
 * [Dialogue](https://github.com/Siccity/Dialogue "Go to github page")
+* [qAI](https://github.com/jlreymendez/qAI "Go to github page")


### PR DESCRIPTION
Appended qAI project at the end of "Projects using xNode" section of Readme.