### PR TITLE
Support for DoubleClick on node to center it.

### DIFF
--- a/Scripts/Editor/NodeEditorAction.cs
+++ b/Scripts/Editor/NodeEditorAction.cs
@@ -22,11 +22,12 @@ namespace XNodeEditor {
         [NonSerialized] private List<Vector2> draggedOutputReroutes = new List<Vector2>();
         private RerouteReference hoveredReroute = new RerouteReference();
         private List<RerouteReference> selectedReroutes = new List<RerouteReference>();
-        private Rect nodeRects;
+        private Rect nodeRects; // Is this used?
         private Vector2 dragBoxStart;
         private UnityEngine.Object[] preBoxSelection;
         private RerouteReference[] preBoxSelectionReroute;
         private Rect selectionBox;
+        private bool isDoubleClick  = false;
 
         private struct RerouteReference {
             public XNode.NodePort port;
@@ -172,6 +173,10 @@ namespace XNodeEditor {
                                 SelectNode(hoveredNode, e.control || e.shift);
                                 if (!e.control && !e.shift) selectedReroutes.Clear();
                             } else if (e.control || e.shift) DeselectNode(hoveredNode);
+
+                            // Cache double click state, but only act on it in MouseUp - Except ClickCount only works in mouseDown.
+                            isDoubleClick = ( e.clickCount == 2 );
+
                             e.Use();
                             currentActivity = NodeActivity.HoldNode;
                         } else if (IsHoveringReroute) {
@@ -239,6 +244,13 @@ namespace XNodeEditor {
                         if (currentActivity == NodeActivity.HoldNode && !(e.control || e.shift)) {
                             selectedReroutes.Clear();
                             SelectNode(hoveredNode, false);
+
+                            // Double click to center node
+                            if ( isDoubleClick )
+                            {
+                                Vector2 nodeDimension = nodeSizes.ContainsKey( hoveredNode ) ? nodeSizes[ hoveredNode ] / 2 : new Vector2(0f, 0f);
+                                panOffset = -hoveredNode.position - nodeDimension;
+                            }
                         }
 
                         // If click reroute, select it.
@@ -273,6 +285,8 @@ namespace XNodeEditor {
                         }
                         isPanning = false;
                     }
+                    // Reset DoubleClick
+                    isDoubleClick = false;
                     break;
                 case EventType.KeyDown:
                     if (EditorGUIUtility.editingTextField) break;


### PR DESCRIPTION
Added support for double clicking on Node header to center that node within the editor window.

Simple quality of life change to allow double clicking on a Node's header area to center that node in the editor window.

It uses event.clickCount to catch double clicks, but that only works correctly in event.mouseDown according to Unity docs, hence setting a bool, which is then caught in the event.mouseUp condition where the actual centering occurs.

Uses event.mouseUp for centering to ensure the node is also selected after centering.