### PR TITLE
Renaming node to nothing

### DIFF
--- a/Scripts/Editor/NodeEditor.cs
+++ b/Scripts/Editor/NodeEditor.cs
@@ -106,6 +106,7 @@ namespace XNodeEditor {
         }
 
         public void Rename(string newName) {
+            if (string.IsNullOrWhiteSpace(newName)) newName = UnityEditor.ObjectNames.NicifyVariableName(target.GetType().Name);
             target.name = newName;
             AssetDatabase.ImportAsset(AssetDatabase.GetAssetPath(target));
         }


### PR DESCRIPTION
Renaming a node to nothing "" is valid, but I can't see any case where you would want that.
Now resets to the original node type name.

The commit history got a bit wierd, but the code looks correct.