### PR TITLE
Lose text focus

### DIFF
--- a/Scripts/Editor/NodeEditorAction.cs
+++ b/Scripts/Editor/NodeEditorAction.cs
@@ -235,6 +235,7 @@ namespace XNodeEditor {
                             // If click outside node, release field focus
                             if (!isPanning) {
                                 EditorGUI.FocusTextInControl(null);
+                                EditorGUIUtility.editingTextField = false;
                             }
                             if (NodeEditorPreferences.GetSettings().autoSave) AssetDatabase.SaveAssets();
                         }


### PR DESCRIPTION
When deselecting a node 
EditorGUI.FocusTextInControl(null) is called.
But that function sets editingTextField to true regardless what is being sent in to previous function.
So the editor stops listening to xNode editor input after that (for instance, the F button).

Proof of problem: https://github.com/Unity-Technologies/UnityCsReference/blob/master/Editor/Mono/EditorGUI.cs#L197