### PR TITLE
UI Sharpness complete fix

### DIFF
--- a/Scripts/Editor/NodeEditorAction.cs
+++ b/Scripts/Editor/NodeEditorAction.cs
@@ -137,12 +137,7 @@ namespace XNodeEditor {
                             Repaint();
                         }
                     } else if (e.button == 1 || e.button == 2) {
-                        Vector2 tempOffset = panOffset;
-                        tempOffset += e.delta * zoom;
-                        // Round value to increase crispyness of UI text
-                        tempOffset.x = Mathf.Round(tempOffset.x);
-                        tempOffset.y = Mathf.Round(tempOffset.y);
-                        panOffset = tempOffset;
+                        panOffset += e.delta * zoom;
                         isPanning = true;
                     }
                     break;
@@ -277,6 +272,7 @@ namespace XNodeEditor {
                                 GenericMenu menu = new GenericMenu();
                                 NodeEditor.GetEditor(hoveredNode).AddContextMenuItems(menu);
                                 menu.DropDown(new Rect(Event.current.mousePosition, Vector2.zero));
+                                e.Use(); // Fixes copy/paste context menu appearing in Unity 5.6.6f2 - doesn't occur in 2018.3.2f1 Probably needs to be used in other places.
                             } else if (!IsHoveringNode) {
                                 GenericMenu menu = new GenericMenu();
                                 graphEditor.AddContextMenuItems(menu);

--- a/Scripts/Editor/NodeEditorWindow.cs
+++ b/Scripts/Editor/NodeEditorWindow.cs
@@ -123,8 +123,9 @@ namespace XNodeEditor {
 
         public Vector2 GridToWindowPositionNoClipped(Vector2 gridPosition) {
             Vector2 center = position.size * 0.5f;
-            float xOffset = (center.x * zoom + (panOffset.x + gridPosition.x));
-            float yOffset = (center.y * zoom + (panOffset.y + gridPosition.y));
+            // UI Sharpness complete fix - Round final offset not panOffset
+            float xOffset = Mathf.Round(center.x * zoom + (panOffset.x + gridPosition.x));
+            float yOffset = Mathf.Round(center.y * zoom + (panOffset.y + gridPosition.y));
             return new Vector2(xOffset, yOffset);
         }
 


### PR DESCRIPTION
After working with xNode in Unity 5.6 for some time I noticed an issue with the UI frequently becoming blurry. Working through the issue it would appear the main problem was with rounding just the panOffset property. 

This had two issues; firstly it wasn't always rounded  ( e.g. when using zoom, it would affect panOffset, but it wasn't being rounded afterwards - so zooming in, panning a bit, then zooming back out would lead to blurred UI), secondly while rounding panOffset is important it didn't address bluriness that occurred when the editor window dimension/rect was not an even width or height.

The resolution to these problems is simply to round the final offset value used to set a nodes position in the window. Thus all that was needed was to round the code in GridToWindowPositionNoClipped().

This requires only a couple of changes. Removal of rounding in NodeEditorAction.cs and adding it to NodeEditorWindow. Now there are other methods that use panOffset to generate co-ordinates, however as far as I can tell not having these rounded does not cause any problems. At worse there may be some sub-pixel movement of port connections or the like, but in practice I've not notice it when interacting with the Node editor.

Further I prefer retaining values as full floats where possible and only rounding prior to being used for display as it ensures that, in this case, panning is still performed as sub-pixel amounts making it smooth and consistent, whilst the actual display is at full pixel increments.

This change was checked in 5.6.6, 2017.4.11, 2018.3.2, although I noticed that without the change the UI always appeared crisp in 2018.3.2 regardless - possibly some Unity editor window code fix that we are unaware of?

Opps, one further change in this commit is adding e.use() to resolve an issue with the Unity copy/paste contextMenu popping up in Unity 5.6 when right-clicking on Node Header. Single line and commented in the code.

In the screenshots below, the top version is with the applied fix showing nice crisp UI, the bottom image showed the original blurry UI. Might need to click on image to zoom to really see the difference.

![halfpixeloffsetfix](https://user-images.githubusercontent.com/648081/52949972-b907d800-3375-11e9-9290-fadfca262876.png)

