### PR TITLE
Zoom out limit feature

### DIFF
--- a/Scripts/Editor/NodeEditorPreferences.cs
+++ b/Scripts/Editor/NodeEditorPreferences.cs
@@ -23,6 +23,7 @@ namespace XNodeEditor {
             [SerializeField] private Color32 _gridBgColor = new Color(0.18f, 0.18f, 0.18f);
             public Color32 gridBgColor { get { return _gridBgColor; } set { _gridBgColor = value; _gridTexture = null; } }
 
+            public float zoomOutLimit = 5f;
             public Color32 highlightColor = new Color32(255, 255, 255, 255);
             public bool gridSnap = true;
             public bool autoSave = true;
@@ -113,7 +114,7 @@ namespace XNodeEditor {
             EditorGUILayout.LabelField("Grid", EditorStyles.boldLabel);
             settings.gridSnap = EditorGUILayout.Toggle(new GUIContent("Snap", "Hold CTRL in editor to invert"), settings.gridSnap);
             settings.zoomToMouse = EditorGUILayout.Toggle(new GUIContent("Zoom to Mouse", "Zooms towards mouse position"), settings.zoomToMouse);
-
+            settings.zoomOutLimit = EditorGUILayout.FloatField(new GUIContent("Zoom out Limit", "Upper limit to zoom"), settings.zoomOutLimit);
             settings.gridLineColor = EditorGUILayout.ColorField("Color", settings.gridLineColor);
             settings.gridBgColor = EditorGUILayout.ColorField(" ", settings.gridBgColor);
             if (GUI.changed) {

--- a/Scripts/Editor/NodeEditorWindow.cs
+++ b/Scripts/Editor/NodeEditorWindow.cs
@@ -61,7 +61,7 @@ namespace XNodeEditor {
         public XNode.NodeGraph graph;
         public Vector2 panOffset { get { return _panOffset; } set { _panOffset = value; Repaint(); } }
         private Vector2 _panOffset;
-        public float zoom { get { return _zoom; } set { _zoom = Mathf.Clamp(value, 1f, 5f); Repaint(); } }
+        public float zoom { get { return _zoom; } set { _zoom = Mathf.Clamp(value, 1f,NodeEditorPreferences.GetSettings().zoomOutLimit); Repaint(); } }
         private float _zoom = 1;
 
         void OnFocus() {

--- a/Scripts/Editor/NodeEditorWindow.cs
+++ b/Scripts/Editor/NodeEditorWindow.cs
@@ -61,7 +61,7 @@ namespace XNodeEditor {
         public XNode.NodeGraph graph;
         public Vector2 panOffset { get { return _panOffset; } set { _panOffset = value; Repaint(); } }
         private Vector2 _panOffset;
-        public float zoom { get { return _zoom; } set { _zoom = Mathf.Clamp(value, 1f,NodeEditorPreferences.GetSettings().zoomOutLimit); Repaint(); } }
+        public float zoom { get { return _zoom; } set { _zoom = Mathf.Clamp(value, 1f, NodeEditorPreferences.GetSettings().zoomOutLimit); Repaint(); } }
         private float _zoom = 1;
 
         void OnFocus() {


### PR DESCRIPTION
I've added a simple zoom out limit, forked from latest version. Sometimes zooming out more become necessary in large graphs.
![image](https://user-images.githubusercontent.com/3215742/54668062-02774e80-4aff-11e9-99ac-1beb3af75e03.png)
