### PR TITLE
Handle selectiton change event

### DIFF
--- a/Scripts/Editor/NodeEditorWindow.cs
+++ b/Scripts/Editor/NodeEditorWindow.cs
@@ -73,7 +73,7 @@ namespace XNodeEditor {
         /// <summary> Handle Selection Change events</summary>
         private void OnSelectionChange() {
             var nodeGraph = Selection.activeObject as XNode.NodeGraph;
-            if (nodeGraph && !AssetDatatbase.Contains(nodeGraph)) {
+            if (nodeGraph && !AssetDatabase.Contains(nodeGraph)) {
                 Open(nodeGraph);
             }
         }

--- a/Scripts/Editor/NodeEditorWindow.cs
+++ b/Scripts/Editor/NodeEditorWindow.cs
@@ -72,11 +72,8 @@ namespace XNodeEditor {
 
         /// <summary> Handle Selection Change events</summary>
         private void OnSelectionChange() {
-            if (!EditorApplication.isPlaying)
-                return;
-
             var nodeGraph = Selection.activeObject as XNode.NodeGraph;
-            if (nodeGraph) {
+            if (nodeGraph && !AssetDatatbase.Contains(nodeGraph)) {
                 Open(nodeGraph);
             }
         }

--- a/Scripts/Editor/NodeEditorWindow.cs
+++ b/Scripts/Editor/NodeEditorWindow.cs
@@ -164,6 +164,7 @@ namespace XNodeEditor {
             return false;
         }
 
+        /// <summary>Open the provided graph in the NodeEditor</summary>
         public static void Open(XNode.NodeGraph graph) {
             if (!graph)
                 return;

--- a/Scripts/Editor/NodeEditorWindow.cs
+++ b/Scripts/Editor/NodeEditorWindow.cs
@@ -70,6 +70,17 @@ namespace XNodeEditor {
             if (graphEditor != null && NodeEditorPreferences.GetSettings().autoSave) AssetDatabase.SaveAssets();
         }
 
+        /// <summary> Handle Selection Change events</summary>
+        private void OnSelectionChange() {
+            if (!EditorApplication.isPlaying)
+                return;
+
+            var nodeGraph = Selection.activeObject as XNode.NodeGraph;
+            if (nodeGraph) {
+                Open(nodeGraph);
+            }
+        }
+
         /// <summary> Create editor window </summary>
         public static NodeEditorWindow Init() {
             NodeEditorWindow w = CreateInstance<NodeEditorWindow>();
@@ -147,12 +158,19 @@ namespace XNodeEditor {
         public static bool OnOpen(int instanceID, int line) {
             XNode.NodeGraph nodeGraph = EditorUtility.InstanceIDToObject(instanceID) as XNode.NodeGraph;
             if (nodeGraph != null) {
-                NodeEditorWindow w = GetWindow(typeof(NodeEditorWindow), false, "xNode", true) as NodeEditorWindow;
-                w.wantsMouseMove = true;
-                w.graph = nodeGraph;
+                Open(nodeGraph);
                 return true;
             }
             return false;
+        }
+
+        public static void Open(XNode.NodeGraph graph) {
+            if (!graph)
+                return;
+
+            NodeEditorWindow w = GetWindow(typeof(NodeEditorWindow), false, "xNode", true) as NodeEditorWindow;
+            w.wantsMouseMove = true;
+            w.graph = graph;
         }
 
         /// <summary> Repaint all open NodeEditorWindows. </summary>

--- a/Scripts/Editor/NodeEditorWindow.cs
+++ b/Scripts/Editor/NodeEditorWindow.cs
@@ -70,9 +70,15 @@ namespace XNodeEditor {
             if (graphEditor != null && NodeEditorPreferences.GetSettings().autoSave) AssetDatabase.SaveAssets();
         }
 
+        [InitializeOnLoadMethod]
+        private static void OnLoad() {
+            Selection.selectionChanged -= OnSelectionChanged;
+            Selection.selectionChanged += OnSelectionChanged;
+        }
+
         /// <summary> Handle Selection Change events</summary>
-        private void OnSelectionChange() {
-            var nodeGraph = Selection.activeObject as XNode.NodeGraph;
+        private static void OnSelectionChanged() {
+            XNode.NodeGraph nodeGraph = Selection.activeObject as XNode.NodeGraph;
             if (nodeGraph && !AssetDatabase.Contains(nodeGraph)) {
                 Open(nodeGraph);
             }
@@ -163,8 +169,7 @@ namespace XNodeEditor {
 
         /// <summary>Open the provided graph in the NodeEditor</summary>
         public static void Open(XNode.NodeGraph graph) {
-            if (!graph)
-                return;
+            if (!graph) return;
 
             NodeEditorWindow w = GetWindow(typeof(NodeEditorWindow), false, "xNode", true) as NodeEditorWindow;
             w.wantsMouseMove = true;


### PR DESCRIPTION
This follows on from a discussion on the Discord server the other day about adding support for unity's OnSelectitonChange event, to show the currently selected graph in the editor window.

To prevent changing any existing expected behaviour, I've written this to only listen to OnSelectionChange events during play mode. This means you still need to double click to view a graph in the editor while outside of play mode. 

I did consider adding an extra setting to the preferences to allow the user to choose their preferred behaviour, but figured I'd see what your thoughts were on the matter first. 

I moved the open logic from the OnOpen method into it's own method, which is then called from both OnOpen and OnSelectionChange. This method is also public, so that users can call it from within their own editor scripts if required (might be useful, e.g. working with subgraphs)