### PR TITLE
NodeEditorGUILayout: Use Input/Output port style

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ sysinfo.txt
 README.md.meta
 LICENSE.md.meta
 CONTRIBUTING.md.meta
+
+.git.meta
+.gitignore.meta
+.gitattributes.meta

--- a/Scripts/Editor/EditorStylesHacks.cs
+++ b/Scripts/Editor/EditorStylesHacks.cs
@@ -45,5 +45,22 @@ namespace XNodeEditor {
                 EditorStylesInstance = EditorStylesInstanceField.GetValue(null) as EditorStyles;
             }
         }
+
+        public static void SetSkin(GUISkin skin)
+        {
+            InvalidateCache();
+            GUI.skin = skin;
+        }
+
+        private static void InvalidateCache()
+        {
+            var field = typeof(EditorStyles).GetField("s_CachedStyles", EditorStylesBindingFlags);
+            if (field == null)
+            {
+                Debug.LogError("No CachedStyles!");
+                return;
+            }
+            field.SetValue(null, new EditorStyles[] { null, null });
+        }
     }
 }

--- a/Scripts/Editor/EditorStylesHacks.cs
+++ b/Scripts/Editor/EditorStylesHacks.cs
@@ -1,0 +1,49 @@
+using System.Reflection;
+using UnityEditor;
+using UnityEngine;
+
+namespace XNodeEditor {
+    public static class EditorStylesHacks {
+        private static FieldInfo EditorLabelField;
+        private static FieldInfo EditorFoldoutField;
+        private static FieldInfo EditorStylesInstanceField;
+        private static EditorStyles EditorStylesInstance;
+
+        private static readonly BindingFlags EditorStylesBindingFlags =
+            BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Instance;
+
+        public static GUIStyle Label {
+            get => EditorStyles.label;
+            set {
+                CacheEditorStylesInstance();
+                if (EditorLabelField == null) {
+                    EditorLabelField = typeof(EditorStyles).GetField("m_Label", EditorStylesBindingFlags);
+                }
+
+                EditorLabelField.SetValue(EditorStylesInstance, value);
+            }
+        }
+
+        public static GUIStyle Foldout {
+            get => EditorStyles.foldout;
+            set {
+                CacheEditorStylesInstance();
+                if (EditorFoldoutField == null) {
+                    EditorFoldoutField = typeof(EditorStyles).GetField("m_Foldout", EditorStylesBindingFlags);
+                }
+
+                EditorFoldoutField.SetValue(EditorStylesInstance, value);
+            }
+        }
+
+        private static void CacheEditorStylesInstance() {
+            if (EditorStylesInstanceField == null) {
+                EditorStylesInstanceField = typeof(EditorStyles).GetField("s_Current", EditorStylesBindingFlags);
+            }
+
+            if (EditorStylesInstance == null) {
+                EditorStylesInstance = EditorStylesInstanceField.GetValue(null) as EditorStyles;
+            }
+        }
+    }
+}

--- a/Scripts/Editor/EditorStylesHacks.cs.meta
+++ b/Scripts/Editor/EditorStylesHacks.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 9850cac2240045df9ade822de8020091
+timeCreated: 1555066067

--- a/Scripts/Editor/NodeEditorGUILayout.cs
+++ b/Scripts/Editor/NodeEditorGUILayout.cs
@@ -117,18 +117,15 @@ namespace XNodeEditor {
                     }
                     switch (showBacking) {
                         case XNode.Node.ShowBackingValue.Unconnected:
-                            // Display a label if port is connected
-                            if (port.IsConnected) EditorGUILayout.LabelField(label != null ? label : new GUIContent(property.displayName), NodeEditorResources.OutputPort, GUILayout.MinWidth(30));
-                            // Display an editable property field if port is not connected
-                            else EditorGUILayout.PropertyField(property, label, includeChildren, GUILayout.MinWidth(30));
+                            DrawStyledPropertyField(property, label, NodeEditorResources.OutputPort, showBacking: !port.IsConnected, includeChildren);
                             break;
                         case XNode.Node.ShowBackingValue.Never:
                             // Display a label
                             EditorGUILayout.LabelField(label != null ? label : new GUIContent(property.displayName), NodeEditorResources.OutputPort, GUILayout.MinWidth(30));
                             break;
                         case XNode.Node.ShowBackingValue.Always:
+                            DrawStyledPropertyField(property, label, NodeEditorResources.OutputPort, showBacking: true, includeChildren);
                             // Display an editable property field
-                            EditorGUILayout.PropertyField(property, label, includeChildren, GUILayout.MinWidth(30));
                             break;
                     }
 

--- a/Scripts/Editor/NodeEditorGUILayout.cs
+++ b/Scripts/Editor/NodeEditorGUILayout.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using UnityEditor;
 using UnityEditorInternal;
 using UnityEngine;
@@ -301,11 +302,8 @@ namespace XNodeEditor {
         private static void DrawStyledPropertyField(SerializedProperty property, GUIContent label, GUIStyle style, bool showBacking = true, bool includeChildren = false) {
             label = label != null ? label : new GUIContent(property.displayName);
 
-            GUIStyle oldFoldout = EditorStylesHacks.Foldout;
-            GUIStyle oldLabel = EditorStylesHacks.Label;
-
-            EditorStylesHacks.Label = style;
-            EditorStylesHacks.Foldout = NodeEditorResources.styles.foldout;
+            var oldSkin = GUI.skin;
+            EditorStylesHacks.SetSkin(NodeEditorResources.styles.skin);
 
             EditorGUILayout.BeginHorizontal();
 
@@ -317,8 +315,7 @@ namespace XNodeEditor {
 
             EditorGUILayout.EndHorizontal();
 
-            EditorStylesHacks.Label = oldLabel;
-            EditorStylesHacks.Foldout = oldFoldout;
+            EditorStylesHacks.SetSkin(oldSkin);
         }
 
         private static ReorderableList CreateReorderableList(string fieldName, List<XNode.NodePort> instancePorts, SerializedProperty arrayData, Type type, SerializedObject serializedObject, XNode.NodePort.IO io, XNode.Node.ConnectionType connectionType, XNode.Node.TypeConstraint typeConstraint, Action<ReorderableList> onCreation) {

--- a/Scripts/Editor/NodeEditorGUILayout.cs
+++ b/Scripts/Editor/NodeEditorGUILayout.cs
@@ -76,14 +76,14 @@ namespace XNodeEditor {
                     GUIStyle inputStyle = NodeEditorResources.styles.inputPort;
                     switch (showBacking) {
                         case XNode.Node.ShowBackingValue.Unconnected:
-                            DrawStyledPropertyField(property, label, inputStyle, showBacking: !port.IsConnected, includeChildren);
+                            DrawStyledPropertyField(property, label, inputStyle, !port.IsConnected, includeChildren);
                             break;
                         case XNode.Node.ShowBackingValue.Never:
                             // Display a label
                             EditorGUILayout.LabelField(label != null ? label : new GUIContent(property.displayName), inputStyle);
                             break;
                         case XNode.Node.ShowBackingValue.Always:
-                            DrawStyledPropertyField(property, label, inputStyle, showBacking: true, includeChildren);
+                            DrawStyledPropertyField(property, label, inputStyle, true, includeChildren);
                             break;
                     }
 
@@ -117,14 +117,14 @@ namespace XNodeEditor {
                     }
                     switch (showBacking) {
                         case XNode.Node.ShowBackingValue.Unconnected:
-                            DrawStyledPropertyField(property, label, NodeEditorResources.OutputPort, showBacking: !port.IsConnected, includeChildren);
+                            DrawStyledPropertyField(property, label, NodeEditorResources.OutputPort, !port.IsConnected, includeChildren);
                             break;
                         case XNode.Node.ShowBackingValue.Never:
                             // Display a label
                             EditorGUILayout.LabelField(label != null ? label : new GUIContent(property.displayName), NodeEditorResources.OutputPort, GUILayout.MinWidth(30));
                             break;
                         case XNode.Node.ShowBackingValue.Always:
-                            DrawStyledPropertyField(property, label, NodeEditorResources.OutputPort, showBacking: true, includeChildren);
+                            DrawStyledPropertyField(property, label, NodeEditorResources.OutputPort, true, includeChildren);
                             // Display an editable property field
                             break;
                     }

--- a/Scripts/Editor/NodeEditorGUILayout.cs
+++ b/Scripts/Editor/NodeEditorGUILayout.cs
@@ -38,7 +38,7 @@ namespace XNodeEditor {
             if (property == null) throw new NullReferenceException();
 
             // If property is not a port, display a regular property field
-            if (port == null) EditorGUILayout.PropertyField(property, label, includeChildren, GUILayout.MinWidth(30));
+            if (port == null) DrawStyledPropertyField(property, label, NodeEditorResources.styles.nodeProperty, true, includeChildren);
             else {
                 Rect rect = new Rect();
 

--- a/Scripts/Editor/NodeEditorGUILayout.cs
+++ b/Scripts/Editor/NodeEditorGUILayout.cs
@@ -2,7 +2,6 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using UnityEditor;
 using UnityEditorInternal;
 using UnityEngine;
@@ -300,13 +299,26 @@ namespace XNodeEditor {
         }
 
         private static void DrawStyledPropertyField(SerializedProperty property, GUIContent label, GUIStyle style, bool showBacking = true, bool includeChildren = false) {
+            label = label != null ? label : new GUIContent(property.displayName);
+
+            GUIStyle oldFoldout = EditorStylesHacks.Foldout;
+            GUIStyle oldLabel = EditorStylesHacks.Label;
+
+            EditorStylesHacks.Label = style;
+            EditorStylesHacks.Foldout = NodeEditorResources.styles.foldout;
+
             EditorGUILayout.BeginHorizontal();
-            // Display a label
-            EditorGUILayout.LabelField(label != null ? label : new GUIContent(property.displayName), style, GUILayout.MaxWidth(70));
-            // Display an editable property field
-            if(showBacking)
-                EditorGUILayout.PropertyField(property, emptyLabel, includeChildren, GUILayout.MinWidth(30));
+
+            if (showBacking) {
+                EditorGUILayout.PropertyField(property, label, includeChildren, GUILayout.MinWidth(30));
+            } else {
+                EditorGUILayout.LabelField(label, style, GUILayout.MinWidth(30));
+            }
+
             EditorGUILayout.EndHorizontal();
+
+            EditorStylesHacks.Label = oldLabel;
+            EditorStylesHacks.Foldout = oldFoldout;
         }
 
         private static ReorderableList CreateReorderableList(string fieldName, List<XNode.NodePort> instancePorts, SerializedProperty arrayData, Type type, SerializedObject serializedObject, XNode.NodePort.IO io, XNode.Node.ConnectionType connectionType, XNode.Node.TypeConstraint typeConstraint, Action<ReorderableList> onCreation) {

--- a/Scripts/Editor/NodeEditorResources.cs
+++ b/Scripts/Editor/NodeEditorResources.cs
@@ -23,6 +23,8 @@ namespace XNodeEditor {
             public Styles() {
                 GUIStyle baseStyle = new GUIStyle(EditorStyles.label);
                 baseStyle.fixedHeight = 18;
+                baseStyle.normal.textColor = Color.white;
+                baseStyle.onNormal.textColor = Color.white;
 
                 inputPort = new GUIStyle(baseStyle);
                 inputPort.alignment = TextAnchor.UpperLeft;

--- a/Scripts/Editor/NodeEditorResources.cs
+++ b/Scripts/Editor/NodeEditorResources.cs
@@ -16,9 +16,9 @@ namespace XNodeEditor {
         // Styles
         public static Styles styles { get { return _styles != null ? _styles : _styles = new Styles(); } }
         public static Styles _styles = null;
-        public static GUIStyle OutputPort { get { return new GUIStyle(EditorStyles.label) { alignment = TextAnchor.UpperRight }; } }
+        public static GUIStyle OutputPort { get { return styles.outputPort;} }
         public class Styles {
-            public GUIStyle inputPort, nodeHeader, nodeBody, tooltip, nodeHighlight, nodeProperty;
+            public GUIStyle inputPort, nodeHeader, nodeBody, tooltip, nodeHighlight, nodeProperty, outputPort, foldout;
 
             public Styles() {
                 GUIStyle baseStyle = new GUIStyle(EditorStyles.label);
@@ -26,8 +26,14 @@ namespace XNodeEditor {
                 baseStyle.normal.textColor = Color.white;
                 baseStyle.onNormal.textColor = Color.white;
 
-                inputPort = new GUIStyle(baseStyle);
+                outputPort = new GUIStyle(baseStyle);
+
+                inputPort = new GUIStyle(EditorStyles.label);
                 inputPort.alignment = TextAnchor.UpperLeft;
+
+                foldout = new GUIStyle(EditorStyles.foldout);
+                foldout.normal.textColor = baseStyle.normal.textColor;
+                foldout.onNormal.textColor = baseStyle.onNormal.textColor;
 
                 nodeProperty = new GUIStyle(baseStyle);
 

--- a/Scripts/Editor/NodeEditorResources.cs
+++ b/Scripts/Editor/NodeEditorResources.cs
@@ -26,7 +26,6 @@ namespace XNodeEditor {
 
                 inputPort = new GUIStyle(baseStyle);
                 inputPort.alignment = TextAnchor.UpperLeft;
-                inputPort.padding.left = 10;
 
                 nodeHeader = new GUIStyle();
                 nodeHeader.alignment = TextAnchor.MiddleCenter;

--- a/Scripts/Editor/NodeEditorResources.cs
+++ b/Scripts/Editor/NodeEditorResources.cs
@@ -18,7 +18,7 @@ namespace XNodeEditor {
         public static Styles _styles = null;
         public static GUIStyle OutputPort { get { return new GUIStyle(EditorStyles.label) { alignment = TextAnchor.UpperRight }; } }
         public class Styles {
-            public GUIStyle inputPort, nodeHeader, nodeBody, tooltip, nodeHighlight;
+            public GUIStyle inputPort, nodeHeader, nodeBody, tooltip, nodeHighlight, nodeProperty;
 
             public Styles() {
                 GUIStyle baseStyle = new GUIStyle("Label");
@@ -26,6 +26,8 @@ namespace XNodeEditor {
 
                 inputPort = new GUIStyle(baseStyle);
                 inputPort.alignment = TextAnchor.UpperLeft;
+
+                nodeProperty = new GUIStyle(baseStyle);
 
                 nodeHeader = new GUIStyle();
                 nodeHeader.alignment = TextAnchor.MiddleCenter;

--- a/Scripts/Editor/NodeEditorResources.cs
+++ b/Scripts/Editor/NodeEditorResources.cs
@@ -1,4 +1,6 @@
-﻿using UnityEditor;
+﻿using System.Collections.Generic;
+using System.Linq;
+using UnityEditor;
 using UnityEngine;
 
 namespace XNodeEditor {
@@ -19,6 +21,7 @@ namespace XNodeEditor {
         public static GUIStyle OutputPort { get { return styles.outputPort;} }
         public class Styles {
             public GUIStyle inputPort, nodeHeader, nodeBody, tooltip, nodeHighlight, nodeProperty, outputPort, foldout;
+            public GUISkin skin;
 
             public Styles() {
                 GUIStyle baseStyle = new GUIStyle(EditorStyles.label);
@@ -53,6 +56,16 @@ namespace XNodeEditor {
 
                 tooltip = new GUIStyle("helpBox");
                 tooltip.alignment = TextAnchor.MiddleCenter;
+
+                skin = GUISkin.Instantiate(EditorGUIUtility.GetBuiltinSkin(EditorSkin.Inspector));
+                List<GUIStyle> custom = skin.customStyles == null ? new List<GUIStyle>() : skin.customStyles.ToList();
+
+                GUIStyle controlLabel = new GUIStyle(baseStyle);
+                controlLabel.name = "ControlLabel";
+                custom.Add(controlLabel);
+                custom.Add(foldout);
+                skin.customStyles = custom.ToArray();
+
             }
         }
 

--- a/Scripts/Editor/NodeEditorResources.cs
+++ b/Scripts/Editor/NodeEditorResources.cs
@@ -21,7 +21,7 @@ namespace XNodeEditor {
             public GUIStyle inputPort, nodeHeader, nodeBody, tooltip, nodeHighlight, nodeProperty;
 
             public Styles() {
-                GUIStyle baseStyle = new GUIStyle("Label");
+                GUIStyle baseStyle = new GUIStyle(EditorStyles.label);
                 baseStyle.fixedHeight = 18;
 
                 inputPort = new GUIStyle(baseStyle);


### PR DESCRIPTION
Modifying node's port styles causes visual inconsistencies because InputPort style is not used at all, and OutputStyle is not used when ShowBackingValue is set to Always.

PropertyField does not allow to specify GUIStyle so I have worked it around by recreating it with separate Label and PropertyField with no label at all.