### PR TITLE
NodeEditorReflection: Catch ReflectionTypeLoadException

### DIFF
--- a/Scripts/Editor/NodeEditorReflection.cs
+++ b/Scripts/Editor/NodeEditorReflection.cs
@@ -75,7 +75,13 @@ namespace XNodeEditor {
             List<System.Type> types = new List<System.Type>();
             System.Reflection.Assembly[] assemblies = System.AppDomain.CurrentDomain.GetAssemblies();
             foreach (Assembly assembly in assemblies) {
-                types.AddRange(assembly.GetTypes().Where(t => !t.IsAbstract && baseType.IsAssignableFrom(t)).ToArray());
+#if UNITY_EDITOR
+                try {
+#endif
+                    types.AddRange(assembly.GetTypes().Where(t => !t.IsAbstract && baseType.IsAssignableFrom(t)).ToArray());
+#if UNITY_EDITOR
+                } catch(ReflectionTypeLoadException) {}
+#endif
             }
             return types.ToArray();
         }

--- a/Scripts/Editor/NodeEditorReflection.cs
+++ b/Scripts/Editor/NodeEditorReflection.cs
@@ -75,13 +75,9 @@ namespace XNodeEditor {
             List<System.Type> types = new List<System.Type>();
             System.Reflection.Assembly[] assemblies = System.AppDomain.CurrentDomain.GetAssemblies();
             foreach (Assembly assembly in assemblies) {
-#if UNITY_EDITOR
                 try {
-#endif
                     types.AddRange(assembly.GetTypes().Where(t => !t.IsAbstract && baseType.IsAssignableFrom(t)).ToArray());
-#if UNITY_EDITOR
                 } catch(ReflectionTypeLoadException) {}
-#endif
             }
             return types.ToArray();
         }


### PR DESCRIPTION
Can happen if some dll can not be loaded for some reason.