### PR TITLE
gitignore: Ignore meta files in main directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ sysinfo.txt
 README.md.meta
 LICENSE.md.meta
 CONTRIBUTING.md.meta
+
+.git.meta
+.gitignore.meta
+.gitattributes.meta


### PR DESCRIPTION
When using this plugin as submodule, Unity generates unneeded .meta files for files such as .git and .gitignore which clutters up the directory. 