### PR TITLE
Fix: RemoveNode order+virtual

### DIFF
--- a/Scripts/Editor/NodeGraphEditor.cs
+++ b/Scripts/Editor/NodeGraphEditor.cs
@@ -93,7 +93,7 @@ namespace XNodeEditor {
         }
 
         /// <summary> Safely remove a node and all its connections. </summary>
-        public void RemoveNode(XNode.Node node) {
+        public virtual void RemoveNode(XNode.Node node) {
             UnityEngine.Object.DestroyImmediate(node, true);
             target.RemoveNode(node);
             if (NodeEditorPreferences.GetSettings().autoSave) AssetDatabase.SaveAssets();

--- a/Scripts/Editor/NodeGraphEditor.cs
+++ b/Scripts/Editor/NodeGraphEditor.cs
@@ -94,8 +94,8 @@ namespace XNodeEditor {
 
         /// <summary> Safely remove a node and all its connections. </summary>
         public virtual void RemoveNode(XNode.Node node) {
-            UnityEngine.Object.DestroyImmediate(node, true);
             target.RemoveNode(node);
+            UnityEngine.Object.DestroyImmediate(node, true);
             if (NodeEditorPreferences.GetSettings().autoSave) AssetDatabase.SaveAssets();
         }
 


### PR DESCRIPTION
switched order of remove function and destroy function.
target.RemoveNode was always getting a null value
-
made RemoveNode function virtual
used for example when a graph wants to block a delete