### PR TITLE
Fixed rename not saving the filename change.

### DIFF
--- a/Scripts/Editor/RenamePopup.cs
+++ b/Scripts/Editor/RenamePopup.cs
@@ -57,7 +57,7 @@ namespace XNodeEditor {
 			else {
 				if (GUILayout.Button("Apply") || (e.isKey && e.keyCode == KeyCode.Return)) {
 					target.name = input;
-					AssetDatabase.ImportAsset(AssetDatabase.GetAssetPath(target));
+					AssetDatabase.RenameAsset(AssetDatabase.GetAssetPath(target), input);
 					Close();
 				}
 			}


### PR DESCRIPTION
- AssetDataBase.ImportAsset was not correctly renaming the asset. Changed it over to use the standard rename method.