### PR TITLE
Allow current assembly nodes to be cached

### DIFF
--- a/Scripts/NodeDataCache.cs
+++ b/Scripts/NodeDataCache.cs
@@ -56,10 +56,14 @@ namespace XNode {
             } else {
                 // Else, check all relevant DDLs (slower)
                 // ignore all unity related assemblies
+                // never ignore current executing assembly
                 foreach (Assembly assembly in assemblies) {
-                    if (assembly.FullName.StartsWith("Unity")) continue;
-                    // unity created assemblies always have version 0.0.0
-                    if (!assembly.FullName.Contains("Version=0.0.0")) continue;
+                    if(assembly != Assembly.GetExecutingAssembly())
+					{
+                        if (assembly.FullName.StartsWith("Unity")) continue;
+                        // unity created assemblies always have version 0.0.0
+                        if (!assembly.FullName.Contains("Version=0.0.0")) continue;
+                    }
                     nodeTypes.AddRange(assembly.GetTypes().Where(t => !t.IsAbstract && baseType.IsAssignableFrom(t)).ToArray());
                 }
             }

--- a/Scripts/NodeDataCache.cs
+++ b/Scripts/NodeDataCache.cs
@@ -58,8 +58,7 @@ namespace XNode {
                 // ignore all unity related assemblies
                 // never ignore current executing assembly
                 foreach (Assembly assembly in assemblies) {
-                    if(assembly != Assembly.GetExecutingAssembly())
-					{
+                    if(assembly != Assembly.GetExecutingAssembly()) {
                         if (assembly.FullName.StartsWith("Unity")) continue;
                         // unity created assemblies always have version 0.0.0
                         if (!assembly.FullName.Contains("Version=0.0.0")) continue;

--- a/Scripts/NodeDataCache.cs
+++ b/Scripts/NodeDataCache.cs
@@ -57,8 +57,9 @@ namespace XNode {
                 // Else, check all relevant DDLs (slower)
                 // ignore all unity related assemblies
                 // never ignore current executing assembly
+                Assembly executingAssembly = Assembly.GetExecutingAssembly();
                 foreach (Assembly assembly in assemblies) {
-                    if(assembly != Assembly.GetExecutingAssembly()) {
+                    if(assembly != executingAssembly) {
                         if (assembly.FullName.StartsWith("Unity")) continue;
                         // unity created assemblies always have version 0.0.0
                         if (!assembly.FullName.Contains("Version=0.0.0")) continue;


### PR DESCRIPTION
This small fix will never ignore caching for current executing assembly when xNode is used as a DLL.
This will allow Node classes created inside the same DLL to be correctly cached.