### PR TITLE
Unified all functions that set the default node name

### DIFF
--- a/Scripts/Editor/NodeEditor.cs
+++ b/Scripts/Editor/NodeEditor.cs
@@ -86,7 +86,7 @@ namespace XNodeEditor {
 
         /// <summary> Rename the node asset. This will trigger a reimport of the node. </summary>
         public void Rename(string newName) {
-            if (newName == null || newName.Trim() == "") newName = UnityEditor.ObjectNames.NicifyVariableName(target.GetType().Name);
+            if (newName == null || newName.Trim() == "") newName = NodeEditorUtilities.NodeDefaultName(target.GetType());
             target.name = newName;
             AssetDatabase.ImportAsset(AssetDatabase.GetAssetPath(target));
         }

--- a/Scripts/Editor/NodeEditor.cs
+++ b/Scripts/Editor/NodeEditor.cs
@@ -88,7 +88,7 @@ namespace XNodeEditor {
         public void Rename(string newName) {
             if (newName == null || newName.Trim() == "") newName = NodeEditorUtilities.NodeDefaultName(target.GetType());
             target.name = newName;
-            AssetDatabase.ImportAsset(AssetDatabase.GetAssetPath(target));
+            AssetDatabase.RenameAsset(AssetDatabase.GetAssetPath(target), target.name);
         }
 
         [AttributeUsage(AttributeTargets.Class)]

--- a/Scripts/Editor/NodeEditorUtilities.cs
+++ b/Scripts/Editor/NodeEditorUtilities.cs
@@ -133,6 +133,15 @@ namespace XNodeEditor {
             } else return type.ToString();
         }
 
+        /// <summary> Returns the default name for the node type. </summary>
+        public static string NodeDefaultName(Type type) {
+            string typeName = type.Name;
+            // Automatically remove redundant 'Node' postfix
+            if (typeName.EndsWith("Node")) typeName = typeName.Substring(0, typeName.LastIndexOf("Node"));
+            typeName = UnityEditor.ObjectNames.NicifyVariableName(typeName);
+            return typeName;
+        }
+
         /// <summary>Creates a new C# Class.</summary>
         [MenuItem("Assets/Create/xNode/Node C# Script", false, 89)]
         private static void CreateNode() {

--- a/Scripts/Editor/NodeGraphEditor.cs
+++ b/Scripts/Editor/NodeGraphEditor.cs
@@ -74,7 +74,7 @@ namespace XNodeEditor {
         public virtual void CreateNode(Type type, Vector2 position) {
             XNode.Node node = target.AddNode(type);
             node.position = position;
-            if (string.IsNullOrEmpty(node.name)) node.name = NodeEditorUtilities.NodeDefaultName(type);
+            if (node.name == null || node.name.Trim() == "") node.name = NodeEditorUtilities.NodeDefaultName(type);
             AssetDatabase.AddObjectToAsset(node, target);
             if (NodeEditorPreferences.GetSettings().autoSave) AssetDatabase.SaveAssets();
             NodeEditorWindow.RepaintAll();

--- a/Scripts/Editor/NodeGraphEditor.cs
+++ b/Scripts/Editor/NodeGraphEditor.cs
@@ -74,12 +74,7 @@ namespace XNodeEditor {
         public virtual void CreateNode(Type type, Vector2 position) {
             XNode.Node node = target.AddNode(type);
             node.position = position;
-            if (string.IsNullOrEmpty(node.name)) {
-                // Automatically remove redundant 'Node' postfix
-                string typeName = type.Name;
-                if (typeName.EndsWith("Node")) typeName = typeName.Substring(0, typeName.LastIndexOf("Node"));
-                node.name = UnityEditor.ObjectNames.NicifyVariableName(typeName);
-            }
+            if (string.IsNullOrEmpty(node.name)) node.name = NodeEditorUtilities.NodeDefaultName(type);
             AssetDatabase.AddObjectToAsset(node, target);
             if (NodeEditorPreferences.GetSettings().autoSave) AssetDatabase.SaveAssets();
             NodeEditorWindow.RepaintAll();

--- a/Scripts/Editor/RenamePopup.cs
+++ b/Scripts/Editor/RenamePopup.cs
@@ -48,7 +48,7 @@ namespace XNodeEditor {
 			// If input is empty, revert name to default instead
 			if (input == null || input.Trim() == "") {
 				if (GUILayout.Button("Revert to default") || (e.isKey && e.keyCode == KeyCode.Return)) {
-					target.name = UnityEditor.ObjectNames.NicifyVariableName(target.GetType().Name);
+                    target.name = NodeEditorUtilities.NodeDefaultName(target.GetType());
 					AssetDatabase.ImportAsset(AssetDatabase.GetAssetPath(target));
 					Close();
 				}

--- a/Scripts/Editor/RenamePopup.cs
+++ b/Scripts/Editor/RenamePopup.cs
@@ -48,8 +48,8 @@ namespace XNodeEditor {
 			// If input is empty, revert name to default instead
 			if (input == null || input.Trim() == "") {
 				if (GUILayout.Button("Revert to default") || (e.isKey && e.keyCode == KeyCode.Return)) {
-                    target.name = NodeEditorUtilities.NodeDefaultName(target.GetType());
-                    AssetDatabase.RenameAsset(AssetDatabase.GetAssetPath(target), target.name);
+					target.name = NodeEditorUtilities.NodeDefaultName(target.GetType());
+					AssetDatabase.RenameAsset(AssetDatabase.GetAssetPath(target), target.name);
 					Close();
 				}
 			}

--- a/Scripts/Editor/RenamePopup.cs
+++ b/Scripts/Editor/RenamePopup.cs
@@ -49,7 +49,7 @@ namespace XNodeEditor {
 			if (input == null || input.Trim() == "") {
 				if (GUILayout.Button("Revert to default") || (e.isKey && e.keyCode == KeyCode.Return)) {
                     target.name = NodeEditorUtilities.NodeDefaultName(target.GetType());
-					AssetDatabase.ImportAsset(AssetDatabase.GetAssetPath(target));
+                    AssetDatabase.RenameAsset(AssetDatabase.GetAssetPath(target), target.name);
 					Close();
 				}
 			}
@@ -57,7 +57,7 @@ namespace XNodeEditor {
 			else {
 				if (GUILayout.Button("Apply") || (e.isKey && e.keyCode == KeyCode.Return)) {
 					target.name = input;
-					AssetDatabase.RenameAsset(AssetDatabase.GetAssetPath(target), input);
+					AssetDatabase.RenameAsset(AssetDatabase.GetAssetPath(target), target.name);
 					Close();
 				}
 			}


### PR DESCRIPTION
There were three different functions that generated its own default node name, all different.
Now unified in NodeEditorUtilties.

Changed two ImportAsset calls to RenameAsset as changed in #149 .

Changed isNullOrEmpty in CreateNode to == null || .Trim() == "" as seen in the rest of the code.