### PR TITLE
Added validation support for Context Menu items

### DIFF
--- a/Scripts/Editor/NodeEditorReflection.cs
+++ b/Scripts/Editor/NodeEditorReflection.cs
@@ -77,7 +77,7 @@ namespace XNodeEditor {
             foreach (Assembly assembly in assemblies) {
                 try {
                     types.AddRange(assembly.GetTypes().Where(t => !t.IsAbstract && baseType.IsAssignableFrom(t)).ToArray());
-                } catch(ReflectionTypeLoadException) {}
+                } catch (ReflectionTypeLoadException) { }
             }
             return types.ToArray();
         }
@@ -88,21 +88,16 @@ namespace XNodeEditor {
                 contextMenu.AddSeparator("");
                 List<string> invalidatedEntries = new List<string>();
                 foreach (var checkValidate in items) {
-                    if (checkValidate.Key.validate && !(bool) checkValidate.Value.Invoke(obj, null))
-                    {
+                    if (checkValidate.Key.validate && !(bool) checkValidate.Value.Invoke(obj, null)) {
                         invalidatedEntries.Add(checkValidate.Key.menuItem);
                     }
                 }
                 for (int i = 0; i < items.Length; i++) {
                     KeyValuePair<ContextMenu, System.Reflection.MethodInfo> kvp = items[i];
-                    if (invalidatedEntries.Contains(kvp.Key.menuItem))
-                    {
+                    if (invalidatedEntries.Contains(kvp.Key.menuItem)) {
                         contextMenu.AddDisabledItem(new GUIContent(kvp.Key.menuItem));
-                    }
-                    else
-                    {
+                    } else {
                         contextMenu.AddItem(new GUIContent(kvp.Key.menuItem), false, () => kvp.Value.Invoke(obj, null));
-
                     }
                 }
             }

--- a/Scripts/Editor/NodeEditorReflection.cs
+++ b/Scripts/Editor/NodeEditorReflection.cs
@@ -83,17 +83,17 @@ namespace XNodeEditor {
         }
 
         public static void AddCustomContextMenuItems(GenericMenu contextMenu, object obj) {
-            KeyValuePair<ContextMenu, System.Reflection.MethodInfo>[] items = GetContextMenuMethods(obj);
+            KeyValuePair<ContextMenu, MethodInfo>[] items = GetContextMenuMethods(obj);
             if (items.Length != 0) {
                 contextMenu.AddSeparator("");
                 List<string> invalidatedEntries = new List<string>();
-                foreach (var checkValidate in items) {
+                foreach (KeyValuePair<ContextMenu, MethodInfo> checkValidate in items) {
                     if (checkValidate.Key.validate && !(bool) checkValidate.Value.Invoke(obj, null)) {
                         invalidatedEntries.Add(checkValidate.Key.menuItem);
                     }
                 }
                 for (int i = 0; i < items.Length; i++) {
-                    KeyValuePair<ContextMenu, System.Reflection.MethodInfo> kvp = items[i];
+                    KeyValuePair<ContextMenu, MethodInfo> kvp = items[i];
                     if (invalidatedEntries.Contains(kvp.Key.menuItem)) {
                         contextMenu.AddDisabledItem(new GUIContent(kvp.Key.menuItem));
                     } else {

--- a/Scripts/Editor/NodeEditorReflection.cs
+++ b/Scripts/Editor/NodeEditorReflection.cs
@@ -86,9 +86,24 @@ namespace XNodeEditor {
             KeyValuePair<ContextMenu, System.Reflection.MethodInfo>[] items = GetContextMenuMethods(obj);
             if (items.Length != 0) {
                 contextMenu.AddSeparator("");
+                List<ContextMenu> invalidatedEntries = new List<ContextMenu>();
+                foreach (var checkValidate in items) {
+                    if (checkValidate.Key.validate && !(bool) checkValidate.Value.Invoke(obj, null))
+                    {
+                        invalidatedEntries.Add(checkValidate.Key);
+                    }
+                }
                 for (int i = 0; i < items.Length; i++) {
                     KeyValuePair<ContextMenu, System.Reflection.MethodInfo> kvp = items[i];
-                    contextMenu.AddItem(new GUIContent(kvp.Key.menuItem), false, () => kvp.Value.Invoke(obj, null));
+                    if (invalidatedEntries.Contains(kvp.Key))
+                    {
+                        contextMenu.AddDisabledItem(new GUIContent(kvp.Key.menuItem));
+                    }
+                    else
+                    {
+                        contextMenu.AddItem(new GUIContent(kvp.Key.menuItem), false, () => kvp.Value.Invoke(obj, null));
+
+                    }
                 }
             }
         }

--- a/Scripts/Editor/NodeEditorReflection.cs
+++ b/Scripts/Editor/NodeEditorReflection.cs
@@ -86,16 +86,16 @@ namespace XNodeEditor {
             KeyValuePair<ContextMenu, System.Reflection.MethodInfo>[] items = GetContextMenuMethods(obj);
             if (items.Length != 0) {
                 contextMenu.AddSeparator("");
-                List<ContextMenu> invalidatedEntries = new List<ContextMenu>();
+                List<string> invalidatedEntries = new List<string>();
                 foreach (var checkValidate in items) {
                     if (checkValidate.Key.validate && !(bool) checkValidate.Value.Invoke(obj, null))
                     {
-                        invalidatedEntries.Add(checkValidate.Key);
+                        invalidatedEntries.Add(checkValidate.Key.menuItem);
                     }
                 }
                 for (int i = 0; i < items.Length; i++) {
                     KeyValuePair<ContextMenu, System.Reflection.MethodInfo> kvp = items[i];
-                    if (invalidatedEntries.Contains(kvp.Key))
+                    if (invalidatedEntries.Contains(kvp.Key.menuItem))
                     {
                         contextMenu.AddDisabledItem(new GUIContent(kvp.Key.menuItem));
                     }


### PR DESCRIPTION
Unity's Context menu attribute supports validation function
https://docs.unity3d.com/ScriptReference/ContextMenu-ctor.html
```c#
public ContextMenu(string itemName, bool isValidateFunction);
```
for example
```c#
[ContextMenu("Add Port")]
void AddPort()
{
    ...
}
[ContextMenu("Add Port", true)]
bool CanAddPort()
{
    return !HasPort(Field.key);
}
```

the validation will be called before menu item is added
if it did not pass validation, it will be disabled (greyed out)