### PR TITLE
Rename Revert

### DIFF
--- a/Scripts/Editor/NodeEditor.cs
+++ b/Scripts/Editor/NodeEditor.cs
@@ -88,7 +88,7 @@ namespace XNodeEditor {
         public void Rename(string newName) {
             if (newName == null || newName.Trim() == "") newName = NodeEditorUtilities.NodeDefaultName(target.GetType());
             target.name = newName;
-            AssetDatabase.RenameAsset(AssetDatabase.GetAssetPath(target), target.name);
+            AssetDatabase.ImportAsset(AssetDatabase.GetAssetPath(target));
         }
 
         [AttributeUsage(AttributeTargets.Class)]

--- a/Scripts/Editor/RenamePopup.cs
+++ b/Scripts/Editor/RenamePopup.cs
@@ -49,16 +49,16 @@ namespace XNodeEditor {
 			if (input == null || input.Trim() == "") {
 				if (GUILayout.Button("Revert to default") || (e.isKey && e.keyCode == KeyCode.Return)) {
 					target.name = NodeEditorUtilities.NodeDefaultName(target.GetType());
-					AssetDatabase.RenameAsset(AssetDatabase.GetAssetPath(target), target.name);
-					Close();
+                    AssetDatabase.ImportAsset(AssetDatabase.GetAssetPath(target));
+                    Close();
 				}
 			}
 			// Rename asset to input text
 			else {
 				if (GUILayout.Button("Apply") || (e.isKey && e.keyCode == KeyCode.Return)) {
 					target.name = input;
-					AssetDatabase.RenameAsset(AssetDatabase.GetAssetPath(target), target.name);
-					Close();
+                    AssetDatabase.ImportAsset(AssetDatabase.GetAssetPath(target));
+                    Close();
 				}
 			}
 		}


### PR DESCRIPTION
- Reverted the rename system back to import as rename was not working across all versions of Unity.
- Kept the new unified functions update.