### PR TITLE
Added type constraints to output port

### DIFF
--- a/Scripts/Node.cs
+++ b/Scripts/Node.cs
@@ -303,6 +303,13 @@ namespace XNode {
                 this.dynamicPortList = dynamicPortList;
                 this.typeConstraint = typeConstraint;
             }
+
+            /// <summary> Mark a serializable field as an output port. You can access this through <see cref="GetOutputPort(string)"/> </summary>
+            /// <param name="backingValue">Should we display the backing value for this port as an editor field? </param>
+            /// <param name="connectionType">Should we allow multiple connections? </param>
+            /// <param name="dynamicPortList">If true, will display a reorderable list of outputs instead of a single port. Will automatically add and display values for lists and arrays </param>
+            [Obsolete("Use constructor with TypeConstraint")]
+            public OutputAttribute(ShowBackingValue backingValue, ConnectionType connectionType, bool dynamicPortList) : this(backingValue, connectionType, TypeConstraint.None, dynamicPortList) { }
         }
 
         [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]

--- a/Scripts/Node.cs
+++ b/Scripts/Node.cs
@@ -290,15 +290,18 @@ namespace XNode {
             [Obsolete("Use dynamicPortList instead")]
             public bool instancePortList { get { return dynamicPortList; } set { dynamicPortList = value; } }
             public bool dynamicPortList;
+            public TypeConstraint typeConstraint;
 
             /// <summary> Mark a serializable field as an output port. You can access this through <see cref="GetOutputPort(string)"/> </summary>
             /// <param name="backingValue">Should we display the backing value for this port as an editor field? </param>
             /// <param name="connectionType">Should we allow multiple connections? </param>
+            /// <param name="typeConstraint">Constrains which input connections can be made from this port </param>
             /// <param name="dynamicPortList">If true, will display a reorderable list of outputs instead of a single port. Will automatically add and display values for lists and arrays </param>
-            public OutputAttribute(ShowBackingValue backingValue = ShowBackingValue.Never, ConnectionType connectionType = ConnectionType.Multiple, bool dynamicPortList = false) {
+            public OutputAttribute(ShowBackingValue backingValue = ShowBackingValue.Never, ConnectionType connectionType = ConnectionType.Multiple, TypeConstraint typeConstraint = TypeConstraint.None, bool dynamicPortList = false) {
                 this.backingValue = backingValue;
                 this.connectionType = connectionType;
                 this.dynamicPortList = dynamicPortList;
+                this.typeConstraint = typeConstraint;
             }
         }
 

--- a/Scripts/NodePort.cs
+++ b/Scripts/NodePort.cs
@@ -67,6 +67,7 @@ namespace XNode {
                 } else if (attribs[i] is Node.OutputAttribute) {
                     _direction = IO.Output;
                     _connectionType = (attribs[i] as Node.OutputAttribute).connectionType;
+                    _typeConstraint = (attribs[i] as Node.OutputAttribute).typeConstraint;
                 }
             }
         }
@@ -255,9 +256,12 @@ namespace XNode {
             else output = port;
             // If there isn't one of each, they can't connect
             if (input == null || output == null) return false;
-            // Check type constraints
+            // Check input type constraints
             if (input.typeConstraint == XNode.Node.TypeConstraint.Inherited && !input.ValueType.IsAssignableFrom(output.ValueType)) return false;
             if (input.typeConstraint == XNode.Node.TypeConstraint.Strict && input.ValueType != output.ValueType) return false;
+            // Check output type constraints
+            if (output.typeConstraint == XNode.Node.TypeConstraint.Inherited && !output.ValueType.IsAssignableFrom(input.ValueType)) return false;
+            if (output.typeConstraint == XNode.Node.TypeConstraint.Strict && output.ValueType != input.ValueType) return false;
             // Success
             return true;
         }


### PR DESCRIPTION
In my case most constraints makes more sense to add to the output port.

Breaking change, added parameter in OutputAttribute after connectionType and before dynamicPortList to follow order of InputAttribute.
Either we don't do anything about it, or add the constraint parameter last, or a second constructor.
Need advice.