### PR TITLE
Ports losing connections

### DIFF
--- a/Scripts/NodeDataCache.cs
+++ b/Scripts/NodeDataCache.cs
@@ -30,11 +30,16 @@ namespace XNode {
                 NodePort staticPort;
                 if (staticPorts.TryGetValue(port.fieldName, out staticPort)) {
                     // If port exists but with wrong settings, remove it. Re-add it later.
-                    if (port.connectionType != staticPort.connectionType || port.IsDynamic || port.direction != staticPort.direction || port.typeConstraint != staticPort.typeConstraint) ports.Remove(port.fieldName);
-                    else port.ValueType = staticPort.ValueType;
+                    if (port.IsDynamic || port.direction != staticPort.direction || port.connectionType != staticPort.connectionType || port.typeConstraint != staticPort.typeConstraint) {
+                        port.ClearConnections();
+                        ports.Remove(port.fieldName);
+                    } else port.ValueType = staticPort.ValueType;
                 }
                 // If port doesn't exist anymore, remove it
-                else if (port.IsStatic) ports.Remove(port.fieldName);
+                else if (port.IsStatic) {
+                    port.ClearConnections();
+                    ports.Remove(port.fieldName);
+                }
             }
             // Add missing ports
             foreach (NodePort staticPort in staticPorts.Values) {


### PR DESCRIPTION
1. When ports was removed, it did not disconnect the connections so the target nodes still had references back to the original port.

2. Ports was losing connections when Input/Output configuration was changed.
It now tries to reconnect the previous connections on the new port. It follows the rules of the Input/Output attribute.
This is a big problem for nodes that change late in the project and exists in many graphs. The clearing of ports is silent and will probably be missed by most.
