### PR TITLE
Odin inspector support

### DIFF
--- a/Scripts/Editor/Drawers/Odin.meta
+++ b/Scripts/Editor/Drawers/Odin.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 327994a52f523b641898a39ff7500a02
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Editor/Drawers/Odin/InNodeEditorAttributeProcessor.cs
+++ b/Scripts/Editor/Drawers/Odin/InNodeEditorAttributeProcessor.cs
@@ -1,0 +1,48 @@
+﻿#if UNITY_EDITOR && ODIN_INSPECTOR
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Sirenix.OdinInspector.Editor;
+using UnityEngine;
+using XNode;
+
+namespace XNodeEditor {
+	internal class OdinNodeInGraphAttributeProcessor<T> : OdinAttributeProcessor<T> where T : Node {
+		public override bool CanProcessSelfAttributes(InspectorProperty property) {
+			return false;
+		}
+
+		public override bool CanProcessChildMemberAttributes(InspectorProperty parentProperty, MemberInfo member) {
+			if (!NodeEditor.inNodeEditor)
+				return false;
+
+			if (member.MemberType == MemberTypes.Field) {
+				switch (member.Name) {
+					case "graph":
+					case "position":
+					case "ports":
+						return true;
+
+					default:
+						break;
+				}
+			}
+
+			return false;
+		}
+
+		public override void ProcessChildMemberAttributes(InspectorProperty parentProperty, MemberInfo member, List<Attribute> attributes) {
+			switch (member.Name) {
+				case "graph":
+				case "position":
+				case "ports":
+					attributes.Add(new HideInInspector());
+					break;
+
+				default:
+					break;
+			}
+		}
+	}
+}
+#endif

--- a/Scripts/Editor/Drawers/Odin/InNodeEditorAttributeProcessor.cs.meta
+++ b/Scripts/Editor/Drawers/Odin/InNodeEditorAttributeProcessor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3cf2561fbfea9a041ac81efbbb5b3e0d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Editor/Drawers/Odin/InputAttributeDrawer.cs
+++ b/Scripts/Editor/Drawers/Odin/InputAttributeDrawer.cs
@@ -1,0 +1,49 @@
+﻿#if UNITY_EDITOR && ODIN_INSPECTOR
+using Sirenix.OdinInspector;
+using Sirenix.OdinInspector.Editor;
+using Sirenix.Utilities.Editor;
+using UnityEngine;
+using XNode;
+
+namespace XNodeEditor {
+	public class InputAttributeDrawer : OdinAttributeDrawer<XNode.Node.InputAttribute> {
+		protected override bool CanDrawAttributeProperty(InspectorProperty property) {
+			Node node = property.Tree.WeakTargets[0] as Node;
+			return node != null;
+		}
+
+		protected override void DrawPropertyLayout(GUIContent label) {
+			Node node = Property.Tree.WeakTargets[0] as Node;
+			NodePort port = node.GetInputPort(Property.Name);
+
+			if (!NodeEditor.inNodeEditor) {
+				if (Attribute.backingValue == XNode.Node.ShowBackingValue.Always || Attribute.backingValue == XNode.Node.ShowBackingValue.Unconnected && !port.IsConnected)
+					CallNextDrawer(label);
+				return;
+			}
+
+			if (Property.Tree.WeakTargets.Count > 1) {
+				SirenixEditorGUI.WarningMessageBox("Cannot draw ports with multiple nodes selected");
+				return;
+			}
+
+			if (port != null) {
+				var portPropoerty = Property.Tree.GetUnityPropertyForPath(Property.UnityPropertyPath);
+				if (portPropoerty == null) {
+					SirenixEditorGUI.ErrorMessageBox("Port property missing at: " + Property.UnityPropertyPath);
+					return;
+				} else {
+					var labelWidth = Property.GetAttribute<LabelWidthAttribute>();
+					if (labelWidth != null)
+						GUIHelper.PushLabelWidth(labelWidth.Width);
+
+					NodeEditorGUILayout.PropertyField(portPropoerty, label == null ? GUIContent.none : label, true, GUILayout.MinWidth(30));
+
+					if (labelWidth != null)
+						GUIHelper.PopLabelWidth();
+				}
+			}
+		}
+	}
+}
+#endif

--- a/Scripts/Editor/Drawers/Odin/InputAttributeDrawer.cs.meta
+++ b/Scripts/Editor/Drawers/Odin/InputAttributeDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2fd590b2e9ea0bd49b6986a2ca9010ab
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Editor/Drawers/Odin/OutputAttributeDrawer.cs
+++ b/Scripts/Editor/Drawers/Odin/OutputAttributeDrawer.cs
@@ -1,0 +1,49 @@
+﻿#if UNITY_EDITOR && ODIN_INSPECTOR
+using Sirenix.OdinInspector;
+using Sirenix.OdinInspector.Editor;
+using Sirenix.Utilities.Editor;
+using UnityEngine;
+using XNode;
+
+namespace XNodeEditor {
+	public class OutputAttributeDrawer : OdinAttributeDrawer<XNode.Node.OutputAttribute> {
+		protected override bool CanDrawAttributeProperty(InspectorProperty property) {
+			Node node = property.Tree.WeakTargets[0] as Node;
+			return node != null;
+		}
+
+		protected override void DrawPropertyLayout(GUIContent label) {
+			Node node = Property.Tree.WeakTargets[0] as Node;
+			NodePort port = node.GetOutputPort(Property.Name);
+
+			if (!NodeEditor.inNodeEditor) {
+				if (Attribute.backingValue == XNode.Node.ShowBackingValue.Always || Attribute.backingValue == XNode.Node.ShowBackingValue.Unconnected && !port.IsConnected)
+					CallNextDrawer(label);
+				return;
+			}
+
+			if (Property.Tree.WeakTargets.Count > 1) {
+				SirenixEditorGUI.WarningMessageBox("Cannot draw ports with multiple nodes selected");
+				return;
+			}
+
+			if (port != null) {
+				var portPropoerty = Property.Tree.GetUnityPropertyForPath(Property.UnityPropertyPath);
+				if (portPropoerty == null) {
+					SirenixEditorGUI.ErrorMessageBox("Port property missing at: " + Property.UnityPropertyPath);
+					return;
+				} else {
+					var labelWidth = Property.GetAttribute<LabelWidthAttribute>();
+					if (labelWidth != null)
+						GUIHelper.PushLabelWidth(labelWidth.Width);
+
+					NodeEditorGUILayout.PropertyField(portPropoerty, label == null ? GUIContent.none : label, true, GUILayout.MinWidth(30));
+
+					if (labelWidth != null)
+						GUIHelper.PopLabelWidth();
+				}
+			}
+		}
+	}
+}
+#endif

--- a/Scripts/Editor/Drawers/Odin/OutputAttributeDrawer.cs.meta
+++ b/Scripts/Editor/Drawers/Odin/OutputAttributeDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e7ebd8f2b42e2384aa109551dc46af88
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Editor/NodeEditor.cs
+++ b/Scripts/Editor/NodeEditor.cs
@@ -3,6 +3,11 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEditor;
 using UnityEngine;
+#if ODIN_INSPECTOR
+using Sirenix.OdinInspector.Editor;
+using Sirenix.Utilities;
+using Sirenix.Utilities.Editor;
+#endif
 
 namespace XNodeEditor {
     /// <summary> Base class to derive custom Node editors from. Use this to create your own custom inspectors and editors for your nodes. </summary>

--- a/Scripts/Editor/NodeEditor.cs
+++ b/Scripts/Editor/NodeEditor.cs
@@ -34,7 +34,7 @@ namespace XNodeEditor {
 
 #if ODIN_INSPECTOR
             // let xNode handle these
-            string[] drawnbyXNode = { "input", "output" };
+            string[] drawnbyXNode = target.Ports.Select(x => x.fieldName).ToArray();
 #endif
 
             // Iterate through serialized properties and draw them like the Inspector (But with ports)
@@ -73,6 +73,7 @@ namespace XNodeEditor {
             // Call repaint so that the graph window elements respond properly to layout changes coming from Odin    
             if (GUIHelper.RepaintRequested) {
                 GUIHelper.ClearRepaintRequest();
+                window.Repaint();
             }
 #else
             window.Repaint();

--- a/Scripts/Editor/NodeEditorBase.cs
+++ b/Scripts/Editor/NodeEditorBase.cs
@@ -26,7 +26,10 @@ namespace XNodeEditor.Internal {
 			get {
 				if (this._objectTree == null) {
 					try {
+						bool wasInEditor = NodeEditor.inNodeEditor;
+						NodeEditor.inNodeEditor = true;
 						this._objectTree = PropertyTree.Create(this.serializedObject);
+						NodeEditor.inNodeEditor = wasInEditor;
 					} catch (ArgumentException ex) {
 						Debug.Log(ex);
 					}

--- a/Scripts/Editor/NodeEditorBase.cs
+++ b/Scripts/Editor/NodeEditorBase.cs
@@ -4,6 +4,9 @@ using System.Collections.Generic;
 using System.Reflection;
 using UnityEditor;
 using UnityEngine;
+#if ODIN_INSPECTOR
+using Sirenix.OdinInspector.Editor;
+#endif
 
 namespace XNodeEditor.Internal {
 	/// <summary> Handles caching of custom editor classes and their target types. Accessible with GetEditor(Type type) </summary>

--- a/Scripts/Editor/NodeEditorBase.cs
+++ b/Scripts/Editor/NodeEditorBase.cs
@@ -17,6 +17,21 @@ namespace XNodeEditor.Internal {
 		public NodeEditorWindow window;
 		public K target;
 		public SerializedObject serializedObject;
+#if ODIN_INSPECTOR
+		private PropertyTree _objectTree;
+		public PropertyTree objectTree {
+			get {
+				if (this._objectTree == null) {
+					try {
+						this._objectTree = PropertyTree.Create(this.serializedObject);
+					} catch (ArgumentException ex) {
+						Debug.Log(ex);
+					}
+				}
+				return this._objectTree;
+			}
+		}
+#endif
 
 		public static T GetEditor(K target, NodeEditorWindow window) {
 			if (target == null) return null;


### PR DESCRIPTION
Adds support for [Sirenix Odin Inspector](https://odininspector.com/).
xNode will still function the same without Odin installed.