### PR TITLE
Show Node Create list When Dragging To Nothing

### DIFF
--- a/Scripts/Editor/NodeEditorAction.cs
+++ b/Scripts/Editor/NodeEditorAction.cs
@@ -31,24 +31,6 @@ namespace XNodeEditor {
         private RerouteReference[] preBoxSelectionReroute;
         private Rect selectionBox;
         private bool isDoubleClick = false;
-
-        private struct RerouteReference {
-            public XNode.NodePort port;
-            public int connectionIndex;
-            public int pointIndex;
-
-            public RerouteReference(XNode.NodePort port, int connectionIndex, int pointIndex) {
-                this.port = port;
-                this.connectionIndex = connectionIndex;
-                this.pointIndex = pointIndex;
-            }
-
-            public void InsertPoint(Vector2 pos) { port.GetReroutePoints(connectionIndex).Insert(pointIndex, pos); }
-            public void SetPoint(Vector2 pos) { port.GetReroutePoints(connectionIndex) [pointIndex] = pos; }
-            public void RemovePoint() { port.GetReroutePoints(connectionIndex).RemoveAt(pointIndex); }
-            public Vector2 GetPoint() { return port.GetReroutePoints(connectionIndex) [pointIndex]; }
-        }
-
         private Vector2 lastMousePosition;
 
         public void Controls() {

--- a/Scripts/Editor/NodeEditorAction.cs
+++ b/Scripts/Editor/NodeEditorAction.cs
@@ -499,13 +499,9 @@ namespace XNodeEditor {
                     NodeEditorGUILayout.DrawPortHandle(rect, bgcol, frcol);
                 }
                 stoppedDraggingPort = true;
-            }
-            else
-            {
-                if(stoppedDraggingPort)
-                {
-                    if(draggedPort != null && draggedPort.IsOutput)
-                    {
+            } else {
+                if (stoppedDraggingPort) {
+                    if (draggedPort != null && draggedPort.IsOutput) {
                         GenericMenu menu = new GenericMenu();
                         graphEditor.AddContextMenuItems(menu, ConnectOnCreate);
                         menu.DropDown(new Rect(Event.current.mousePosition, Vector2.zero));
@@ -515,10 +511,10 @@ namespace XNodeEditor {
             }
             if (hoveredPort != null)
                 draggedPort = hoveredPort;
-            else if(draggedOutputTarget != null)
+            else if (draggedOutputTarget != null)
                 draggedPort = draggedOutputTarget;
 
-                Repaint();
+            Repaint();
         }
 
         bool IsHoveringTitle(XNode.Node node) {
@@ -532,12 +528,12 @@ namespace XNodeEditor {
             Rect windowRect = new Rect(nodePos, new Vector2(width / zoom, 30 / zoom));
             return windowRect.Contains(mousePos);
         }
-        private void ConnectOnCreate(object obj = default(object))
-        {
-            if(graph.nodes.Last().Ports.Where(r => r.IsInput == true).Any(r => r.ValueType == draggedPort.ValueType))
-                draggedPort.Connect(graph.nodes.Last().Ports.Where(r => r.IsInput == true).Where(r => r.ValueType == draggedPort.ValueType).ToArray()[0]);
+        
+        private void ConnectOnCreate(object obj = default(object)) {
+            if (graph.nodes.Last().Ports.Where(r => r.IsInput == true).Any(r => r.ValueType == draggedPort.ValueType))
+                draggedPort.Connect(graph.nodes.Last().Ports.Where(r => r.IsInput == true).Where(r => r.ValueType == draggedPort.ValueType).ToArray() [0]);
             else
-                draggedPort.Connect(graph.nodes.Last().Ports.Where(r => r.IsInput == true).ToArray()[0]);
+                draggedPort.Connect(graph.nodes.Last().Ports.Where(r => r.IsInput == true).ToArray() [0]);
         }
     }
 }

--- a/Scripts/Editor/NodeEditorAction.cs
+++ b/Scripts/Editor/NodeEditorAction.cs
@@ -500,13 +500,5 @@ namespace XNodeEditor {
             else
                 draggedPort.Connect(graph.nodes.Last().Ports.Where(r => r.IsInput == true).ToArray()[0]);
         }
-        private bool SomeNodesSelected()
-        {
-            foreach(UnityEngine.Object obj in Selection.objects)
-            {
-                return graph.nodes.Any(r => r.Equals((XNode.Node)obj));
-            }
-            return false;
-        }
     }
 }

--- a/Scripts/Editor/NodeEditorAction.cs
+++ b/Scripts/Editor/NodeEditorAction.cs
@@ -31,7 +31,7 @@ namespace XNodeEditor {
         private Rect selectionBox;
         private bool isDoubleClick = false;
 
-        private bool stoppedDraggingPort = true;
+        public static bool stoppedDraggingPort = true;
         private XNode.NodePort draggedPort;
 
         private struct RerouteReference {
@@ -529,7 +529,7 @@ namespace XNodeEditor {
             return windowRect.Contains(mousePos);
         }
         
-        private void ConnectOnCreate(object obj = default(object)) {
+        public void ConnectOnCreate() {
             if (graph.nodes.Last().Ports.Where(r => r.IsInput == true).Any(r => r.ValueType == draggedPort.ValueType))
                 draggedPort.Connect(graph.nodes.Last().Ports.Where(r => r.IsInput == true).Where(r => r.ValueType == draggedPort.ValueType).ToArray() [0]);
             else

--- a/Scripts/Editor/NodeEditorAction.cs
+++ b/Scripts/Editor/NodeEditorAction.cs
@@ -218,7 +218,7 @@ namespace XNodeEditor {
                                 }
                             }
                             // Open context menu for auto-connection
-                            else if (autoConnectOutput != null) {
+                            else if (NodeEditorPreferences.GetSettings().dragToCreate && autoConnectOutput != null) {
                                 GenericMenu menu = new GenericMenu();
                                 graphEditor.AddContextMenuItems(menu);
                                 menu.DropDown(new Rect(Event.current.mousePosition, Vector2.zero));

--- a/Scripts/Editor/NodeEditorAction.cs
+++ b/Scripts/Editor/NodeEditorAction.cs
@@ -503,7 +503,7 @@ namespace XNodeEditor {
                 if (stoppedDraggingPort) {
                     if (draggedPort != null && draggedPort.IsOutput) {
                         GenericMenu menu = new GenericMenu();
-                        graphEditor.AddContextMenuItems(menu, ConnectOnCreate);
+                        graphEditor.AddContextMenuItems(menu);
                         menu.DropDown(new Rect(Event.current.mousePosition, Vector2.zero));
                     }
                     stoppedDraggingPort = false;
@@ -528,7 +528,7 @@ namespace XNodeEditor {
             Rect windowRect = new Rect(nodePos, new Vector2(width / zoom, 30 / zoom));
             return windowRect.Contains(mousePos);
         }
-        
+
         public void ConnectOnCreate() {
             if (graph.nodes.Last().Ports.Where(r => r.IsInput == true).Any(r => r.ValueType == draggedPort.ValueType))
                 draggedPort.Connect(graph.nodes.Last().Ports.Where(r => r.IsInput == true).Where(r => r.ValueType == draggedPort.ValueType).ToArray() [0]);

--- a/Scripts/Editor/NodeEditorAction.cs
+++ b/Scripts/Editor/NodeEditorAction.cs
@@ -487,8 +487,6 @@ namespace XNodeEditor {
                     NodeEditorGUILayout.DrawPortHandle(rect, bgcol, frcol);
                 }
             }
-
-            Repaint();
         }
 
         bool IsHoveringTitle(XNode.Node node) {

--- a/Scripts/Editor/NodeEditorPreferences.cs
+++ b/Scripts/Editor/NodeEditorPreferences.cs
@@ -32,6 +32,7 @@ namespace XNodeEditor {
             public Color32 highlightColor = new Color32(255, 255, 255, 255);
             public bool gridSnap = true;
             public bool autoSave = true;
+            public bool dragToCreate = true;
             public bool zoomToMouse = true;
             public bool portTooltips = true;
             [SerializeField] private string typeColorsData = "";
@@ -149,6 +150,7 @@ namespace XNodeEditor {
             settings.highlightColor = EditorGUILayout.ColorField("Selection", settings.highlightColor);
             settings.noodleType = (NoodleType) EditorGUILayout.EnumPopup("Noodle type", (Enum) settings.noodleType);
             settings.portTooltips = EditorGUILayout.Toggle("Port Tooltips", settings.portTooltips);
+            settings.dragToCreate = EditorGUILayout.Toggle(new GUIContent("Drag to Create", "Drag a port connection anywhere on the grid to create and connect a node"), settings.dragToCreate);
             if (GUI.changed) {
                 SavePrefs(key, settings);
                 NodeEditorWindow.RepaintAll();

--- a/Scripts/Editor/NodeGraphEditor.cs
+++ b/Scripts/Editor/NodeGraphEditor.cs
@@ -50,11 +50,11 @@ namespace XNodeEditor {
                 //Get node context menu path
                 string path = GetNodeMenuName(type);
                 if (string.IsNullOrEmpty(path)) continue;
-                
-                    menu.AddItem(new GUIContent(path), false, () => {
-                        CreateNode(type, pos);
-                        if(!NodeEditorWindow.stoppedDraggingPort) NodeEditorWindow.current.ConnectOnCreate();
-                    });
+
+                menu.AddItem(new GUIContent(path), false, () => {
+                    CreateNode(type, pos);
+                    if (!NodeEditorWindow.stoppedDraggingPort) NodeEditorWindow.current.ConnectOnCreate();
+                });
             }
             menu.AddSeparator("");
             if (NodeEditorWindow.copyBuffer != null && NodeEditorWindow.copyBuffer.Length > 0) menu.AddItem(new GUIContent("Paste"), false, () => NodeEditorWindow.current.PasteNodes(pos));
@@ -115,7 +115,7 @@ namespace XNodeEditor {
 
         [AttributeUsage(AttributeTargets.Class)]
         public class CustomNodeGraphEditorAttribute : Attribute,
-            XNodeEditor.Internal.NodeEditorBase<NodeGraphEditor, NodeGraphEditor.CustomNodeGraphEditorAttribute, XNode.NodeGraph>.INodeEditorAttrib {
+        XNodeEditor.Internal.NodeEditorBase<NodeGraphEditor, NodeGraphEditor.CustomNodeGraphEditorAttribute, XNode.NodeGraph>.INodeEditorAttrib {
             private Type inspectedType;
             public string editorPrefsKey;
             /// <summary> Tells a NodeGraphEditor which Graph type it is an editor for </summary>

--- a/Scripts/Editor/NodeGraphEditor.cs
+++ b/Scripts/Editor/NodeGraphEditor.cs
@@ -52,8 +52,8 @@ namespace XNodeEditor {
                 if (string.IsNullOrEmpty(path)) continue;
 
                 menu.AddItem(new GUIContent(path), false, () => {
-                    CreateNode(type, pos);
-                    if (!NodeEditorWindow.stoppedDraggingPort) NodeEditorWindow.current.ConnectOnCreate();
+                    XNode.Node node = CreateNode(type, pos);
+                    NodeEditorWindow.current.AutoConnect(node);
                 });
             }
             menu.AddSeparator("");
@@ -88,13 +88,14 @@ namespace XNodeEditor {
         }
 
         /// <summary> Create a node and save it in the graph asset </summary>
-        public virtual void CreateNode(Type type, Vector2 position) {
+        public virtual XNode.Node CreateNode(Type type, Vector2 position) {
             XNode.Node node = target.AddNode(type);
             node.position = position;
             if (node.name == null || node.name.Trim() == "") node.name = NodeEditorUtilities.NodeDefaultName(type);
             AssetDatabase.AddObjectToAsset(node, target);
             if (NodeEditorPreferences.GetSettings().autoSave) AssetDatabase.SaveAssets();
             NodeEditorWindow.RepaintAll();
+            return node;
         }
 
         /// <summary> Creates a copy of the original node in the graph </summary>

--- a/Scripts/Editor/NodeGraphEditor.cs
+++ b/Scripts/Editor/NodeGraphEditor.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEditor;
@@ -38,14 +38,14 @@ namespace XNodeEditor {
             if (NodeEditorUtilities.GetAttrib(type, out attrib)) // Return custom path
                 return attrib.menuName;
             else // Return generated path
-                return ObjectNames.NicifyVariableName(type.ToString().Replace('.', '/'));
+                return NodeEditorUtilities.NodeDefaultPath(type);
         }
 
         /// <summary> Add items for the context menu when right-clicking this node. Override to add custom menu items. </summary>
         public virtual void AddContextMenuItems(GenericMenu menu, GenericMenu.MenuFunction2 call = default(GenericMenu.MenuFunction2)) {
             Vector2 pos = NodeEditorWindow.current.WindowToGridPosition(Event.current.mousePosition);
-            for (int i = 0; i < NodeEditorWindow.nodeTypes.Length; i++) {
-                Type type = NodeEditorWindow.nodeTypes[i];
+            for (int i = 0; i < NodeEditorReflection.nodeTypes.Length; i++) {
+                Type type = NodeEditorReflection.nodeTypes[i];
 
                 //Get node context menu path
                 string path = GetNodeMenuName(type);
@@ -62,8 +62,10 @@ namespace XNodeEditor {
                     });
             }
             menu.AddSeparator("");
-            menu.AddItem(new GUIContent("Preferences"), false, () => NodeEditorWindow.OpenPreferences());
-            NodeEditorWindow.AddCustomContextMenuItems(menu, target);
+            if (NodeEditorWindow.copyBuffer != null && NodeEditorWindow.copyBuffer.Length > 0) menu.AddItem(new GUIContent("Paste"), false, () => NodeEditorWindow.current.PasteNodes(pos));
+            else menu.AddDisabledItem(new GUIContent("Paste"));
+            menu.AddItem(new GUIContent("Preferences"), false, () => NodeEditorReflection.OpenPreferences());
+            menu.AddCustomContextMenuItems(target);
         }
 
         public virtual Color GetPortColor(XNode.NodePort port) {
@@ -74,16 +76,27 @@ namespace XNodeEditor {
             return NodeEditorPreferences.GetTypeColor(type);
         }
 
+        public virtual string GetPortTooltip(XNode.NodePort port) {
+            Type portType = port.ValueType;
+            string tooltip = "";
+            tooltip = portType.PrettyName();
+            if (port.IsOutput) {
+                object obj = port.node.GetValue(port);
+                tooltip += " = " + (obj != null ? obj.ToString() : "null");
+            }
+            return tooltip;
+        }
+
+        /// <summary> Deal with objects dropped into the graph through DragAndDrop </summary>
+        public virtual void OnDropObjects(UnityEngine.Object[] objects) {
+            Debug.Log("No OnDropItems override defined for " + GetType());
+        }
+
         /// <summary> Create a node and save it in the graph asset </summary>
         public virtual void CreateNode(Type type, Vector2 position) {
             XNode.Node node = target.AddNode(type);
             node.position = position;
-            if (string.IsNullOrEmpty(node.name)) {
-                // Automatically remove redundant 'Node' postfix
-                string typeName = type.Name;
-                if (typeName.EndsWith("Node")) typeName = typeName.Substring(0, typeName.LastIndexOf("Node"));
-                node.name = UnityEditor.ObjectNames.NicifyVariableName(typeName);
-            }
+            if (node.name == null || node.name.Trim() == "") node.name = NodeEditorUtilities.NodeDefaultName(type);
             AssetDatabase.AddObjectToAsset(node, target);
             if (NodeEditorPreferences.GetSettings().autoSave) AssetDatabase.SaveAssets();
             NodeEditorWindow.RepaintAll();
@@ -107,7 +120,7 @@ namespace XNodeEditor {
 
         [AttributeUsage(AttributeTargets.Class)]
         public class CustomNodeGraphEditorAttribute : Attribute,
-        XNodeEditor.Internal.NodeEditorBase<NodeGraphEditor, NodeGraphEditor.CustomNodeGraphEditorAttribute, XNode.NodeGraph>.INodeEditorAttrib {
+            XNodeEditor.Internal.NodeEditorBase<NodeGraphEditor, NodeGraphEditor.CustomNodeGraphEditorAttribute, XNode.NodeGraph>.INodeEditorAttrib {
             private Type inspectedType;
             public string editorPrefsKey;
             /// <summary> Tells a NodeGraphEditor which Graph type it is an editor for </summary>

--- a/Scripts/Editor/NodeGraphEditor.cs
+++ b/Scripts/Editor/NodeGraphEditor.cs
@@ -51,7 +51,7 @@ namespace XNodeEditor {
                 string path = GetNodeMenuName(type);
                 if (string.IsNullOrEmpty(path)) continue;
 
-                if(call != null)
+                if (call != null)
                     menu.AddItem(new GUIContent(path), false, () => {
                         CreateNode(type, pos);
                         call(null);

--- a/Scripts/Editor/NodeGraphEditor.cs
+++ b/Scripts/Editor/NodeGraphEditor.cs
@@ -42,7 +42,7 @@ namespace XNodeEditor {
         }
 
         /// <summary> Add items for the context menu when right-clicking this node. Override to add custom menu items. </summary>
-        public virtual void AddContextMenuItems(GenericMenu menu, GenericMenu.MenuFunction2 call = default(GenericMenu.MenuFunction2)) {
+        public virtual void AddContextMenuItems(GenericMenu menu) {
             Vector2 pos = NodeEditorWindow.current.WindowToGridPosition(Event.current.mousePosition);
             for (int i = 0; i < NodeEditorReflection.nodeTypes.Length; i++) {
                 Type type = NodeEditorReflection.nodeTypes[i];
@@ -50,15 +50,10 @@ namespace XNodeEditor {
                 //Get node context menu path
                 string path = GetNodeMenuName(type);
                 if (string.IsNullOrEmpty(path)) continue;
-
-                if (call != null)
+                
                     menu.AddItem(new GUIContent(path), false, () => {
                         CreateNode(type, pos);
-                        call(null);
-                    });
-                else
-                    menu.AddItem(new GUIContent(path), false, () => {
-                        CreateNode(type, pos);
+                        if(!NodeEditorWindow.stoppedDraggingPort) NodeEditorWindow.current.ConnectOnCreate();
                     });
             }
             menu.AddSeparator("");


### PR DESCRIPTION
## Review : 
this feature shows up generic menu when dragging to nothing and let's you choose from it the node you want and create it.

its on unreal engine 4 and it makes creating nodes super fast and improves workflow.

it also plugs automatically to the input port of its type :
![drag feature](https://user-images.githubusercontent.com/54871067/64220437-bdd34a00-cec9-11e9-98c5-69b03b66c36f.gif)

## Q&A :

**1 - what if there is no port of its type?**

if there is no port of the dragged port type it will choose the first port.
![Bug noticed yay](https://user-images.githubusercontent.com/54871067/64220593-32a68400-ceca-11e9-9b25-4988a196a721.gif)

**2 - How about when you want to disconnect nodes will menu show up?**

no, it won't.
![other bug noticed yay](https://user-images.githubusercontent.com/54871067/64220956-6df58280-cecb-11e9-84b3-e33c3b90be31.gif)


