### PR TITLE
Added easy customization to the DynamicPortList

### DIFF
--- a/Scripts/Editor/NodeEditorGUILayout.cs
+++ b/Scripts/Editor/NodeEditorGUILayout.cs
@@ -11,7 +11,9 @@ namespace XNodeEditor {
     /// <summary> xNode-specific version of <see cref="EditorGUILayout"/> </summary>
     public static class NodeEditorGUILayout {
 
-        private static readonly Dictionary<UnityEngine.Object, Dictionary<string, ReorderableList>> reorderableListCache = new Dictionary<UnityEngine.Object, Dictionary<string, ReorderableList>>();
+        private static readonly Dictionary<UnityEngine.Object, Dictionary<string, ReorderableList>> ReorderableListCache =
+            new Dictionary<UnityEngine.Object, Dictionary<string, ReorderableList>>();
+        
         private static int reorderableListIndex = -1;
 
         /// <summary> Make a field for a serialized property. Automatically displays relevant node port. </summary>
@@ -264,7 +266,7 @@ namespace XNodeEditor {
             string[] parts = port.fieldName.Split(' ');
             if (parts.Length != 2) return false;
             Dictionary<string, ReorderableList> cache;
-            if (reorderableListCache.TryGetValue(port.node, out cache)) {
+            if (ReorderableListCache.TryGetValue(port.node, out cache)) {
                 ReorderableList list;
                 if (cache.TryGetValue(parts[0], out list)) return true;
             }
@@ -294,15 +296,15 @@ namespace XNodeEditor {
 
             ReorderableList list = null;
             Dictionary<string, ReorderableList> rlc;
-            if (reorderableListCache.TryGetValue(serializedObject.targetObject, out rlc)) {
+            if (ReorderableListCache.TryGetValue(serializedObject.targetObject, out rlc)) {
                 if (!rlc.TryGetValue(fieldName, out list)) list = null;
             }
             // If a ReorderableList isn't cached for this array, do so.
             if (list == null) {
                 SerializedProperty arrayData = serializedObject.FindProperty(fieldName);
                 list = CreateReorderableList(fieldName, dynamicPorts, arrayData, type, serializedObject, io, connectionType, typeConstraint, onCreation);
-                if (reorderableListCache.TryGetValue(serializedObject.targetObject, out rlc)) rlc.Add(fieldName, list);
-                else reorderableListCache.Add(serializedObject.targetObject, new Dictionary<string, ReorderableList>() { { fieldName, list } });
+                if (ReorderableListCache.TryGetValue(serializedObject.targetObject, out rlc)) rlc.Add(fieldName, list);
+                else ReorderableListCache.Add(serializedObject.targetObject, new Dictionary<string, ReorderableList>() { { fieldName, list } });
             }
             list.list = dynamicPorts;
             list.DoLayoutList();

--- a/Scripts/Editor/NodeEditorGUILayout.cs
+++ b/Scripts/Editor/NodeEditorGUILayout.cs
@@ -25,7 +25,7 @@ namespace XNodeEditor {
         public static void PropertyField(SerializedProperty property, GUIContent label, bool includeChildren = true, params GUILayoutOption[] options) {
             if (property == null) throw new NullReferenceException();
             XNode.Node node = property.serializedObject.targetObject as XNode.Node;
-            XNode.NodePort port = node.GetPort(property.name);
+            XNode.NodePort port = node != null ? node.GetPort(property.name) : null;
             PropertyField(property, label, port, includeChildren);
         }
 

--- a/Scripts/Node.cs
+++ b/Scripts/Node.cs
@@ -311,6 +311,33 @@ namespace XNode {
             [Obsolete("Use constructor with TypeConstraint")]
             public OutputAttribute(ShowBackingValue backingValue, ConnectionType connectionType, bool dynamicPortList) : this(backingValue, connectionType, TypeConstraint.None, dynamicPortList) { }
         }
+        
+        /// <summary>
+        /// Use this to specify how a dynamic port list should be configured.
+        /// </summary>
+        [AttributeUsage(AttributeTargets.Field)]
+        public class DynamicPortListSettingsAttribute : Attribute
+        {
+            /// <summary>
+            /// Set this to true to use the first connection name as the name of each entry in the port list.
+            /// </summary>
+            public bool useConnectionNames;
+
+            /// <summary>
+            /// Set to true to show the entry index in the entry name.
+            /// </summary>
+            public bool showEntryIndexes;
+            
+            /// <summary>
+            /// Use this to define the entry name for elements in the list.
+            /// </summary>
+            public string defaultEntryName = null;
+
+            /// <summary>
+            /// The format to use to display the list values.
+            /// </summary>
+            public string entryFormat = null;
+        }
 
         [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
         public class CreateNodeMenuAttribute : Attribute {


### PR DESCRIPTION
I have added a DynamicPortListSettings attribute so users can change how the dynamicPortList renders elements in the orderable list.

The new attribute allows the user to opt to use the port connections to generate entry names from the type of the first connected child of each port. Also, this attribute allows the user to show or hide indexes from the list, change the entry name format and set a default name for empty ports.

I have also updated the code to use C# 4.0 features and cleaned the NodeEditorGUILayout class. I have removed redundancies such as redundant initializations and conditions. I have converted some if statements to switches to make the code easier to read.

I have done extensive tests on the new feature, and old features around the DynamicPortList and everything seems to be working as it should.