### PR TITLE
Don't invoke repaint every frame

### DIFF
--- a/Scripts/Editor/NodeEditor.cs
+++ b/Scripts/Editor/NodeEditor.cs
@@ -72,8 +72,6 @@ namespace XNodeEditor {
                 GUIHelper.ClearRepaintRequest();
                 window.Repaint();
             }
-#else
-            window.Repaint();
 #endif
 
 #if ODIN_INSPECTOR

--- a/Scripts/Editor/NodeEditorAction.cs
+++ b/Scripts/Editor/NodeEditorAction.cs
@@ -309,6 +309,7 @@ namespace XNodeEditor {
                                 SelectNode(node, true);
                             }
                         }
+                        Repaint();
                     }
                     break;
                 case EventType.ValidateCommand:


### PR DESCRIPTION
A repaint was added in the Custom Node Editor code that causes the window to repaint every frame.
This was not present before 43bcb54fda4378e46a678c866242954248a63702 and should not be there.

Tested before and after with the Math Graph example.