### PR TITLE
Optimize GC allocations in NodeEditorWindow

### DIFF
--- a/Scripts/Editor/NodeEditorGUI.cs
+++ b/Scripts/Editor/NodeEditorGUI.cs
@@ -15,6 +15,7 @@ namespace XNodeEditor {
         private int topPadding { get { return isDocked() ? 19 : 22; } }
         /// <summary> Executed after all other window GUI. Useful if Zoom is ruining your day. Automatically resets after being run.</summary>
         public event Action onLateGUI;
+        private static readonly Vector3[] polyLineTempArray = new Vector3[2];
 
         private void OnGUI() {
             Event e = Event.current;
@@ -115,24 +116,41 @@ namespace XNodeEditor {
             contextMenu.DropDown(new Rect(Event.current.mousePosition, Vector2.zero));
             if (NodeEditorPreferences.GetSettings().autoSave) AssetDatabase.SaveAssets();
         }
+        
+        static Vector3 CalculateBezierPoint(in Vector3 p0, in Vector3 p1, in Vector3 p2, in Vector3 p3, float t) {
+            float u = 1 - t;
+            float tt = t * t, uu = u * u;
+            float uuu = uu * u, ttt = tt * t;
+            return (uuu * p0) + (3 * uu * t * p1) + (3 * u * tt * p2) + (ttt * p3);
+        }
 
+        /// <summary> Draws a line segment without allocating temporary arrays </summary>
+        static void DrawAAPolyLineNonAlloc(float thickness, in Vector3 p0, in Vector3 p1) {
+            polyLineTempArray[0] = p0;
+            polyLineTempArray[1] = p1;
+            Handles.DrawAAPolyLine(thickness, polyLineTempArray);
+        }
+        
         /// <summary> Draw a bezier from output to input in grid coordinates </summary>
         public void DrawNoodle(Gradient gradient, NoodlePath path, NoodleStroke stroke, float thickness, List<Vector2> gridPoints) {
-            Vector2[] windowPoints = gridPoints.Select(x => GridToWindowPosition(x)).ToArray();
+            // convert grid points to window points
+            for (int i = 0; i < gridPoints.Count; ++i)
+                gridPoints[i] = GridToWindowPosition(gridPoints[i]);
+
             Handles.color = gradient.Evaluate(0f);
             int length = gridPoints.Count;
             switch (path) {
                 case NoodlePath.Curvy:
                     Vector2 outputTangent = Vector2.right;
                     for (int i = 0; i < length - 1; i++) {
-                        Vector2 inputTangent = Vector2.left;
+                        Vector2 inputTangent;
                         // Cached most variables that repeat themselves here to avoid so many indexer calls :p
-                        Vector2 point_a = windowPoints[i];
-                        Vector2 point_b = windowPoints[i + 1];
+                        Vector2 point_a = gridPoints[i];
+                        Vector2 point_b = gridPoints[i + 1];
                         float dist_ab = Vector2.Distance(point_a, point_b);
-                        if (i == 0) outputTangent = Vector2.right * dist_ab * 0.01f * zoom;
+                        if (i == 0) outputTangent = zoom * dist_ab * 0.01f * Vector2.right;
                         if (i < length - 2) {
-                            Vector2 point_c = windowPoints[i + 2];
+                            Vector2 point_c = gridPoints[i + 2];
                             Vector2 ab = (point_b - point_a).normalized;
                             Vector2 cb = (point_b - point_c).normalized;
                             Vector2 ac = (point_c - point_a).normalized;
@@ -140,37 +158,41 @@ namespace XNodeEditor {
                             float tangentLength = (dist_ab + Vector2.Distance(point_b, point_c)) * 0.005f * zoom;
                             float side = ((ac.x * (point_b.y - point_a.y)) - (ac.y * (point_b.x - point_a.x)));
 
-                            p = new Vector2(-p.y, p.x) * Mathf.Sign(side) * tangentLength;
+                            p = tangentLength * Mathf.Sign(side) * new Vector2(-p.y, p.x);
                             inputTangent = p;
                         } else {
-                            inputTangent = Vector2.left * dist_ab * 0.01f * zoom;
+                            inputTangent = zoom * dist_ab * 0.01f * Vector2.left;
                         }
 
                         // Calculates the tangents for the bezier's curves.
-                        Vector2 tangent_a = point_a + outputTangent * 50 / zoom;
-                        Vector2 tangent_b = point_b + inputTangent * 50 / zoom;
+                        float zoomCoef = 50 / zoom;
+                        Vector2 tangent_a = point_a + outputTangent * zoomCoef;
+                        Vector2 tangent_b = point_b + inputTangent * zoomCoef;
                         // Hover effect.
                         int division = Mathf.RoundToInt(.2f * dist_ab) + 3;
-                        Vector3[] points = Handles.MakeBezierPoints(point_a, point_b, tangent_a, tangent_b, division);
-                        int draw = 0;
                         // Coloring and bezier drawing.
-                        for (int j = 0; j < points.Length - 1; j++) {
+                        int draw = 0;
+                        Vector3 bezierPrevious = point_a;
+                        for (int j = 1; j < division; ++j)
+                        {
                             if (stroke == NoodleStroke.Dashed) {
                                 draw++;
                                 if (draw >= 2) draw = -2;
                                 if (draw < 0) continue;
                             }
-
-                            if (i == gridPoints.Count - 2) Handles.color = gradient.Evaluate((j + 1f) / points.Length);
-                            Handles.DrawAAPolyLine(thickness, points[j], points[j + 1]);
+                            if (i == length - 2)
+                                Handles.color = gradient.Evaluate((j + 1f) / division);
+                            Vector3 bezierNext = CalculateBezierPoint(point_a, tangent_a, tangent_b, point_b, j / (float)division);
+                            DrawAAPolyLineNonAlloc(thickness, bezierPrevious, bezierNext);
+                            bezierPrevious = bezierNext;
                         }
                         outputTangent = -inputTangent;
                     }
                     break;
                 case NoodlePath.Straight:
                     for (int i = 0; i < length - 1; i++) {
-                        Vector2 point_a = windowPoints[i];
-                        Vector2 point_b = windowPoints[i + 1];
+                        Vector2 point_a = gridPoints[i];
+                        Vector2 point_b = gridPoints[i + 1];
                         // Draws the line with the coloring.
                         Vector2 prev_point = point_a;
                         // Approximately one segment per 5 pixels
@@ -182,8 +204,8 @@ namespace XNodeEditor {
                             float t = j / (float) segments;
                             Vector2 lerp = Vector2.Lerp(point_a, point_b, t);
                             if (draw > 0) {
-                                if (i == gridPoints.Count - 2) Handles.color = gradient.Evaluate(t);
-                                Handles.DrawAAPolyLine(thickness, prev_point, lerp);
+                                if (i == length - 2) Handles.color = gradient.Evaluate(t);
+                                DrawAAPolyLineNonAlloc(thickness, prev_point, lerp);
                             }
                             prev_point = lerp;
                             if (stroke == NoodleStroke.Dashed && draw >= 2) draw = -2;
@@ -193,49 +215,49 @@ namespace XNodeEditor {
                 case NoodlePath.Angled:
                     for (int i = 0; i < length - 1; i++) {
                         if (i == length - 1) continue; // Skip last index
-                        if (windowPoints[i].x <= windowPoints[i + 1].x - (50 / zoom)) {
-                            float midpoint = (windowPoints[i].x + windowPoints[i + 1].x) * 0.5f;
-                            Vector2 start_1 = windowPoints[i];
-                            Vector2 end_1 = windowPoints[i + 1];
+                        if (gridPoints[i].x <= gridPoints[i + 1].x - (50 / zoom)) {
+                            float midpoint = (gridPoints[i].x + gridPoints[i + 1].x) * 0.5f;
+                            Vector2 start_1 = gridPoints[i];
+                            Vector2 end_1 = gridPoints[i + 1];
                             start_1.x = midpoint;
                             end_1.x = midpoint;
-                            if (i == gridPoints.Count - 2) {
-                                Handles.DrawAAPolyLine(thickness, windowPoints[i], start_1);
+                            if (i == length - 2) {
+                                DrawAAPolyLineNonAlloc(thickness, gridPoints[i], start_1);
                                 Handles.color = gradient.Evaluate(0.5f);
-                                Handles.DrawAAPolyLine(thickness, start_1, end_1);
+                                DrawAAPolyLineNonAlloc(thickness, start_1, end_1);
                                 Handles.color = gradient.Evaluate(1f);
-                                Handles.DrawAAPolyLine(thickness, end_1, windowPoints[i + 1]);
+                                DrawAAPolyLineNonAlloc(thickness, end_1, gridPoints[i + 1]);
                             } else {
-                                Handles.DrawAAPolyLine(thickness, windowPoints[i], start_1);
-                                Handles.DrawAAPolyLine(thickness, start_1, end_1);
-                                Handles.DrawAAPolyLine(thickness, end_1, windowPoints[i + 1]);
+                                DrawAAPolyLineNonAlloc(thickness, gridPoints[i], start_1);
+                                DrawAAPolyLineNonAlloc(thickness, start_1, end_1);
+                                DrawAAPolyLineNonAlloc(thickness, end_1, gridPoints[i + 1]);
                             }
                         } else {
-                            float midpoint = (windowPoints[i].y + windowPoints[i + 1].y) * 0.5f;
-                            Vector2 start_1 = windowPoints[i];
-                            Vector2 end_1 = windowPoints[i + 1];
+                            float midpoint = (gridPoints[i].y + gridPoints[i + 1].y) * 0.5f;
+                            Vector2 start_1 = gridPoints[i];
+                            Vector2 end_1 = gridPoints[i + 1];
                             start_1.x += 25 / zoom;
                             end_1.x -= 25 / zoom;
                             Vector2 start_2 = start_1;
                             Vector2 end_2 = end_1;
                             start_2.y = midpoint;
                             end_2.y = midpoint;
-                            if (i == gridPoints.Count - 2) {
-                                Handles.DrawAAPolyLine(thickness, windowPoints[i], start_1);
+                            if (i == length - 2) {
+                                DrawAAPolyLineNonAlloc(thickness, gridPoints[i], start_1);
                                 Handles.color = gradient.Evaluate(0.25f);
-                                Handles.DrawAAPolyLine(thickness, start_1, start_2);
+                                DrawAAPolyLineNonAlloc(thickness, start_1, start_2);
                                 Handles.color = gradient.Evaluate(0.5f);
-                                Handles.DrawAAPolyLine(thickness, start_2, end_2);
+                                DrawAAPolyLineNonAlloc(thickness, start_2, end_2);
                                 Handles.color = gradient.Evaluate(0.75f);
-                                Handles.DrawAAPolyLine(thickness, end_2, end_1);
+                                DrawAAPolyLineNonAlloc(thickness, end_2, end_1);
                                 Handles.color = gradient.Evaluate(1f);
-                                Handles.DrawAAPolyLine(thickness, end_1, windowPoints[i + 1]);
+                                DrawAAPolyLineNonAlloc(thickness, end_1, gridPoints[i + 1]);
                             } else {
-                                Handles.DrawAAPolyLine(thickness, windowPoints[i], start_1);
-                                Handles.DrawAAPolyLine(thickness, start_1, start_2);
-                                Handles.DrawAAPolyLine(thickness, start_2, end_2);
-                                Handles.DrawAAPolyLine(thickness, end_2, end_1);
-                                Handles.DrawAAPolyLine(thickness, end_1, windowPoints[i + 1]);
+                                DrawAAPolyLineNonAlloc(thickness, gridPoints[i], start_1);
+                                DrawAAPolyLineNonAlloc(thickness, start_1, start_2);
+                                DrawAAPolyLineNonAlloc(thickness, start_2, end_2);
+                                DrawAAPolyLineNonAlloc(thickness, end_2, end_1);
+                                DrawAAPolyLineNonAlloc(thickness, end_1, gridPoints[i + 1]);
                             }
                         }
                     }

--- a/Scripts/Editor/NodeEditorGUI.cs
+++ b/Scripts/Editor/NodeEditorGUI.cs
@@ -117,7 +117,7 @@ namespace XNodeEditor {
             if (NodeEditorPreferences.GetSettings().autoSave) AssetDatabase.SaveAssets();
         }
         
-        static Vector3 CalculateBezierPoint(in Vector3 p0, in Vector3 p1, in Vector3 p2, in Vector3 p3, float t) {
+        static Vector2 CalculateBezierPoint(in Vector2 p0, in Vector2 p1, in Vector2 p2, in Vector2 p3, float t) {
             float u = 1 - t;
             float tt = t * t, uu = u * u;
             float uuu = uu * u, ttt = tt * t;
@@ -125,7 +125,7 @@ namespace XNodeEditor {
         }
 
         /// <summary> Draws a line segment without allocating temporary arrays </summary>
-        static void DrawAAPolyLineNonAlloc(float thickness, in Vector3 p0, in Vector3 p1) {
+        static void DrawAAPolyLineNonAlloc(float thickness, in Vector2 p0, in Vector2 p1) {
             polyLineTempArray[0] = p0;
             polyLineTempArray[1] = p1;
             Handles.DrawAAPolyLine(thickness, polyLineTempArray);
@@ -172,8 +172,8 @@ namespace XNodeEditor {
                         int division = Mathf.RoundToInt(.2f * dist_ab) + 3;
                         // Coloring and bezier drawing.
                         int draw = 0;
-                        Vector3 bezierPrevious = point_a;
-                        for (int j = 1; j < division; ++j)
+                        Vector2 bezierPrevious = point_a;
+                        for (int j = 1; j <= division; ++j)
                         {
                             if (stroke == NoodleStroke.Dashed) {
                                 draw++;
@@ -182,7 +182,7 @@ namespace XNodeEditor {
                             }
                             if (i == length - 2)
                                 Handles.color = gradient.Evaluate((j + 1f) / division);
-                            Vector3 bezierNext = CalculateBezierPoint(point_a, tangent_a, tangent_b, point_b, j / (float)division);
+                            Vector2 bezierNext = CalculateBezierPoint(point_a, tangent_a, tangent_b, point_b, j / (float)division);
                             DrawAAPolyLineNonAlloc(thickness, bezierPrevious, bezierNext);
                             bezierPrevious = bezierNext;
                         }


### PR DESCRIPTION
This pull request contains a few optimizations that reduce the GC pressure when drawing bezier curves (and other types of lines) in NodeEditorWindow. The way this is achieved is the following:

- Implement bezier curve calculations as a standalone method instead of using the built-in Unity function which allocates an array for each call
```csharp
static Vector2 CalculateBezierPoint(in Vector2 p0, in Vector2 p1, in Vector2 p2, in Vector2 p3, float t) {
    float u = 1 - t;
    float tt = t * t, uu = u * u;
    float uuu = uu * u, ttt = tt * t;
    return (uuu * p0) + (3 * uu * t * p1) + (3 * u * tt * p2) + (ttt * p3);
}
```
- Use a temporary array to pass arguments to `Handles.DrawAAPolyLine`
```csharp
/// <summary> Draws a line segment without allocating temporary arrays </summary>
static void DrawAAPolyLineNonAlloc(float thickness, in Vector2 p0, in Vector2 p1) {
    polyLineTempArray[0] = p0;
    polyLineTempArray[1] = p1;
    Handles.DrawAAPolyLine(thickness, polyLineTempArray);
}
```
- Process the `gridPoints` list in-place instead of using LINQ and allocating an array for the result
    - This is ugly because it mutates the argument passed to the method. This shouldn't matter the way `DrawNoodle` is currently used, but should be minded in the future.