### PR TITLE
Make NodeGraphicEditor::OnGui extendable.

### DIFF
--- a/Scripts/Editor/NodeEditorGUI.cs
+++ b/Scripts/Editor/NodeEditorGUI.cs
@@ -17,7 +17,7 @@ namespace XNodeEditor {
         public event Action onLateGUI;
         private static readonly Vector3[] polyLineTempArray = new Vector3[2];
 
-        private void OnGUI() {
+        protected virtual void OnGUI() {
             Event e = Event.current;
             Matrix4x4 m = GUI.matrix;
             if (graph == null) return;


### PR DESCRIPTION
Have OnGui virtual and protected, to ease the exension of NodeGraphicEditor by the user.

It allows extending classes (e.g. MyEditorWindow : XNodeEditor.NodeEditorWindow) to add custom, project-specific GUI components in the editor window.