### PR TITLE
Generic "Edit graph" button for node and graph inspectors

### DIFF
--- a/Scripts/Editor/GraphAndNodeEditor.cs
+++ b/Scripts/Editor/GraphAndNodeEditor.cs
@@ -1,0 +1,128 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using UnityEditor;
+using UnityEngine;
+
+namespace XNodeEditor {
+
+    [CustomEditor(typeof(XNode.NodeGraph), true)]
+    public class GlobalGraphEditor : Editor {
+        public override void OnInspectorGUI() {
+            serializedObject.Update();
+
+            var graphObject = serializedObject.targetObject as XNode.NodeGraph;
+            
+            var button = GUILayout.Button("Edit graph", GUILayout.Height(40));
+            if (button && graphObject != null) {
+                NodeEditorWindow.Open(graphObject);
+            }
+            
+            GUILayout.Space(EditorGUIUtility.singleLineHeight);
+            GUILayout.Label("Raw data", "BoldLabel");
+
+            DrawDefaultInspector();
+            
+            serializedObject.ApplyModifiedProperties();
+        }
+    }
+    
+
+    [CustomEditor(typeof(XNode.Node), true)]
+    public class GlobalNodeEditor : Editor {
+        private SerializedProperty graph;
+        
+        private void OnEnable() {
+            graph = serializedObject.FindProperty("graph");
+        }
+
+        public override void OnInspectorGUI() {
+            serializedObject.Update();
+
+            var graphObject = GetTargetObjectOfProperty(graph) as XNode.NodeGraph;
+            
+            var button = GUILayout.Button("Edit graph", GUILayout.Height(40));
+            if (button && graphObject != null) {
+                NodeEditorWindow.Open(graphObject);
+            }
+
+            GUILayout.Space(EditorGUIUtility.singleLineHeight);
+            GUILayout.Label("Raw data", "BoldLabel");
+
+            // Now draw the node itself.
+            DrawDefaultInspector();
+            
+            serializedObject.ApplyModifiedProperties();
+        }
+        
+        
+        
+        // HELPER METHODS BELOW RETRIEVED FROM https://github.com/lordofduct/spacepuppy-unity-framework/blob/master/SpacepuppyBaseEditor/EditorHelper.cs
+        // BASED ON POST https://forum.unity.com/threads/get-a-general-object-value-from-serializedproperty.327098/#post-2309545
+        // AND ADJUSTED SLIGHTLY AFTERWARDS
+        
+        /// <summary>
+        /// Gets the object the property represents.
+        /// </summary>
+        /// <param name="prop"></param>
+        /// <returns></returns>
+        private static object GetTargetObjectOfProperty(SerializedProperty prop) {
+            if (prop == null) return null;
+
+            var path = prop.propertyPath.Replace(".Array.data[", "[");
+            object obj = prop.serializedObject.targetObject;
+            var elements = path.Split('.');
+            foreach (var element in elements) {
+                if (element.Contains("[")) {
+                    var elementName = element.Substring(0, element.IndexOf("[", StringComparison.Ordinal));
+                    var index = Convert.ToInt32(element.Substring(element.IndexOf("[", StringComparison.Ordinal))
+                        .Replace("[", "")
+                        .Replace("]", ""));
+                    obj = GetValue_Imp(obj, elementName, index);
+                }
+                else {
+                    obj = GetValue_Imp(obj, element);
+                }
+            }
+
+            return obj;
+        }
+        
+        private static object GetValue_Imp(object source, string name) {
+            if (source == null)
+                return null;
+            var type = source.GetType();
+
+            while (type != null) {
+                var f = type.GetField(name, BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance);
+                if (f != null)
+                    return f.GetValue(source);
+
+                var p = type.GetProperty(name,
+                    BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
+                if (p != null)
+                    return p.GetValue(source, null);
+
+                type = type.BaseType;
+            }
+
+            return null;
+        }
+        
+        private static object GetValue_Imp(object source, string name, int index) {
+            if (!(GetValue_Imp(source, name) is IEnumerable enumerable)) return null;
+            var enm = enumerable.GetEnumerator();
+            //while (index-- >= 0)
+            //    enm.MoveNext();
+            //return enm.Current;
+
+            for (var i = 0; i <= index; i++) {
+                if (!enm.MoveNext()) return null;
+            }
+
+            return enm.Current;
+        }
+    }
+
+}

--- a/Scripts/Editor/GraphAndNodeEditor.cs
+++ b/Scripts/Editor/GraphAndNodeEditor.cs
@@ -6,45 +6,33 @@ using UnityEditor;
 using UnityEngine;
 
 namespace XNodeEditor {
-
+    /// <summary> Override graph inspector to show an 'Open Graph' button at the top </summary>
     [CustomEditor(typeof(XNode.NodeGraph), true)]
     public class GlobalGraphEditor : Editor {
         public override void OnInspectorGUI() {
             serializedObject.Update();
 
-            var graphObject = serializedObject.targetObject as XNode.NodeGraph;
-            
-            var button = GUILayout.Button("Edit graph", GUILayout.Height(40));
-            if (button && graphObject != null) {
-                NodeEditorWindow.Open(graphObject);
+            if (GUILayout.Button("Edit graph", GUILayout.Height(40))) {
+                NodeEditorWindow.Open(serializedObject.targetObject as XNode.NodeGraph);
             }
-            
+
             GUILayout.Space(EditorGUIUtility.singleLineHeight);
             GUILayout.Label("Raw data", "BoldLabel");
 
             DrawDefaultInspector();
-            
+
             serializedObject.ApplyModifiedProperties();
         }
     }
-    
 
     [CustomEditor(typeof(XNode.Node), true)]
     public class GlobalNodeEditor : Editor {
-        private SerializedProperty graph;
-        
-        private void OnEnable() {
-            graph = serializedObject.FindProperty("graph");
-        }
-
         public override void OnInspectorGUI() {
             serializedObject.Update();
 
-            var graphObject = GetTargetObjectOfProperty(graph) as XNode.NodeGraph;
-            
-            var button = GUILayout.Button("Edit graph", GUILayout.Height(40));
-            if (button && graphObject != null) {
-                NodeEditorWindow.Open(graphObject);
+            if (GUILayout.Button("Edit graph", GUILayout.Height(40))) {
+                SerializedProperty graphProp = serializedObject.FindProperty("graph");
+                NodeEditorWindow.Open(graphProp.objectReferenceValue as XNode.NodeGraph);
             }
 
             GUILayout.Space(EditorGUIUtility.singleLineHeight);
@@ -52,77 +40,8 @@ namespace XNodeEditor {
 
             // Now draw the node itself.
             DrawDefaultInspector();
-            
+
             serializedObject.ApplyModifiedProperties();
         }
-        
-        
-        
-        // HELPER METHODS BELOW RETRIEVED FROM https://github.com/lordofduct/spacepuppy-unity-framework/blob/master/SpacepuppyBaseEditor/EditorHelper.cs
-        // BASED ON POST https://forum.unity.com/threads/get-a-general-object-value-from-serializedproperty.327098/#post-2309545
-        // AND ADJUSTED SLIGHTLY AFTERWARDS
-        
-        /// <summary>
-        /// Gets the object the property represents.
-        /// </summary>
-        /// <param name="prop"></param>
-        /// <returns></returns>
-        private static object GetTargetObjectOfProperty(SerializedProperty prop) {
-            if (prop == null) return null;
-
-            var path = prop.propertyPath.Replace(".Array.data[", "[");
-            object obj = prop.serializedObject.targetObject;
-            var elements = path.Split('.');
-            foreach (var element in elements) {
-                if (element.Contains("[")) {
-                    var elementName = element.Substring(0, element.IndexOf("[", StringComparison.Ordinal));
-                    var index = Convert.ToInt32(element.Substring(element.IndexOf("[", StringComparison.Ordinal))
-                        .Replace("[", "")
-                        .Replace("]", ""));
-                    obj = GetValue_Imp(obj, elementName, index);
-                }
-                else {
-                    obj = GetValue_Imp(obj, element);
-                }
-            }
-
-            return obj;
-        }
-        
-        private static object GetValue_Imp(object source, string name) {
-            if (source == null)
-                return null;
-            var type = source.GetType();
-
-            while (type != null) {
-                var f = type.GetField(name, BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance);
-                if (f != null)
-                    return f.GetValue(source);
-
-                var p = type.GetProperty(name,
-                    BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
-                if (p != null)
-                    return p.GetValue(source, null);
-
-                type = type.BaseType;
-            }
-
-            return null;
-        }
-        
-        private static object GetValue_Imp(object source, string name, int index) {
-            if (!(GetValue_Imp(source, name) is IEnumerable enumerable)) return null;
-            var enm = enumerable.GetEnumerator();
-            //while (index-- >= 0)
-            //    enm.MoveNext();
-            //return enm.Current;
-
-            for (var i = 0; i <= index; i++) {
-                if (!enm.MoveNext()) return null;
-            }
-
-            return enm.Current;
-        }
     }
-
 }

--- a/Scripts/Editor/GraphAndNodeEditor.cs
+++ b/Scripts/Editor/GraphAndNodeEditor.cs
@@ -32,7 +32,8 @@ namespace XNodeEditor {
 
             if (GUILayout.Button("Edit graph", GUILayout.Height(40))) {
                 SerializedProperty graphProp = serializedObject.FindProperty("graph");
-                NodeEditorWindow.Open(graphProp.objectReferenceValue as XNode.NodeGraph);
+                NodeEditorWindow w = NodeEditorWindow.Open(graphProp.objectReferenceValue as XNode.NodeGraph);
+                w.Home(); // Focus selected node
             }
 
             GUILayout.Space(EditorGUIUtility.singleLineHeight);

--- a/Scripts/Editor/GraphAndNodeEditor.cs.meta
+++ b/Scripts/Editor/GraphAndNodeEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bdd6e443125ccac4dad0665515759637
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Editor/NodeEditorWindow.cs
+++ b/Scripts/Editor/NodeEditorWindow.cs
@@ -187,12 +187,13 @@ namespace XNodeEditor {
         }
 
         /// <summary>Open the provided graph in the NodeEditor</summary>
-        public static void Open(XNode.NodeGraph graph) {
-            if (!graph) return;
+        public static NodeEditorWindow Open(XNode.NodeGraph graph) {
+            if (!graph) return null;
 
             NodeEditorWindow w = GetWindow(typeof(NodeEditorWindow), false, "xNode", true) as NodeEditorWindow;
             w.wantsMouseMove = true;
             w.graph = graph;
+            return w;
         }
 
         /// <summary> Repaint all open NodeEditorWindows. </summary>


### PR DESCRIPTION
"Before" on the left, "after" on the right.

![image](https://user-images.githubusercontent.com/17273782/71322179-02a8de00-24c5-11ea-9fa7-b926d3e8824b.png)

Minor convenience that adds the buttons without introducing any destructive changes to the subsequent normal Inspectors. The buttons are ever-present, large, and hopefully sufficiently attention-grabbing for your users. When I first started xNode up, I was rather surprised that this wasn't a thing.