### PR TITLE
Special class attribute allowing for I/O tooltip overrides (or hiding the result)

### DIFF
--- a/Scripts/Attributes/OverrideTooltipAttribute.cs
+++ b/Scripts/Attributes/OverrideTooltipAttribute.cs
@@ -1,0 +1,23 @@
+﻿using System;
+
+namespace XNodeEditor {
+    
+    /// <summary>
+    /// <para>When applied to the definition of a custom class, allows for the tooltip shown beside the nodes to be overriden.</para>
+    /// Optionally, whether an output node's value is shown in the tooltip can also be turned off.
+    /// Leaving the tooltip override blank or null will leave the normal tooltip (type name) in place.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class)]
+    public sealed class OverrideTooltipAttribute : Attribute {
+        public readonly bool overrideTooltip;
+        public readonly string tooltip;
+        public readonly bool hideValue;
+            
+        public OverrideTooltipAttribute(string tooltip = "", bool hideValue = false) {
+            overrideTooltip = !string.IsNullOrEmpty(tooltip);
+            if (overrideTooltip) this.tooltip = tooltip;
+            this.hideValue = hideValue;
+        }
+    }
+    
+}

--- a/Scripts/Attributes/OverrideTooltipAttribute.cs.meta
+++ b/Scripts/Attributes/OverrideTooltipAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b578945cab8b7c643ac937a49febb57e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Editor/NodeGraphEditor.cs
+++ b/Scripts/Editor/NodeGraphEditor.cs
@@ -123,9 +123,17 @@ namespace XNodeEditor {
         public virtual string GetPortTooltip(XNode.NodePort port) {
             Type portType = port.ValueType;
             string tooltip = "";
-            tooltip = portType.PrettyName();
-            if (port.IsOutput) {
-                object obj = port.node.GetValue(port);
+
+            // Now allow tooltips to be overridden or to have their values hidden based on attribute usage
+            var targetType = portType.HasElementType ? portType.GetElementType() : portType; // For arrays and lists.
+            // ReSharper disable once PossibleNullReferenceException
+            var attr = ((OverrideTooltipAttribute[])targetType
+                .GetCustomAttributes(typeof(OverrideTooltipAttribute), false)).SingleOrDefault();
+            tooltip = attr?.overrideTooltip ?? false ? attr.tooltip : targetType.PrettyName();
+            var hideValue = attr?.hideValue ?? false;
+            // ReSharper disable once InvertIf
+            if (!hideValue && port.IsOutput) {
+                var obj = port.node.GetValue(port);
                 tooltip += " = " + (obj != null ? obj.ToString() : "null");
             }
             return tooltip;


### PR DESCRIPTION
When using long, nested namespaces and nested classes, you can find yourself in ridiculous situations where your tooltips go out of screen. With these changes, you can use an attribute to remedy this.

As usual, "before" is to the left, "after" is to the right:
![image](https://user-images.githubusercontent.com/17273782/71322331-bfe80580-24c6-11ea-8445-b7789f7b6b84.png)
Additionally, hiding values is not necessary -- you may only rename if you so desire:
![image](https://user-images.githubusercontent.com/17273782/71322338-d55d2f80-24c6-11ea-9cab-ca5423a1bc90.png)
(The attribute also supports hiding the value only.)

Usage example for the first image:
```csharp
[Output(dynamicPortList = true)]
public RootAxisLink[] axes;

// And the dummy linking class itself -- attribute is applied 
// bool parameter is whether the result should be hidden; leave string empty to NOT override tooltip.
[Serializable, OverrideTooltip("Root-Axis link", true)] public class RootAxisLink { };
```

**NB:** This commit uses modern C# features such as null coalescing. I'm not too clear on the backwards-compatibility policy of the repo, and will edit if necessary.