### PR TITLE
Example fix for the dynamic port "serialisation desync" problem.

### DIFF
--- a/Scripts/Editor/NodeEditorAction.cs
+++ b/Scripts/Editor/NodeEditorAction.cs
@@ -457,8 +457,8 @@ namespace XNodeEditor {
 
                         XNode.Node newNodeIn, newNodeOut;
                         if (substitutes.TryGetValue(inputPort.node, out newNodeIn) && substitutes.TryGetValue(outputPort.node, out newNodeOut)) {
-                            newNodeIn.UpdateStaticPorts();
-                            newNodeOut.UpdateStaticPorts();
+                            newNodeIn.UpdatePorts();
+                            newNodeOut.UpdatePorts();
                             inputPort = newNodeIn.GetInputPort(inputPort.fieldName);
                             outputPort = newNodeOut.GetOutputPort(outputPort.fieldName);
                         }

--- a/Scripts/Editor/NodeEditorGUILayout.cs
+++ b/Scripts/Editor/NodeEditorGUILayout.cs
@@ -326,6 +326,8 @@ namespace XNodeEditor {
             }
             list.list = dynamicPorts;
             list.DoLayoutList();
+            
+            node.UpdatePorts();
         }
 
         private static ReorderableList CreateReorderableList(string fieldName, List<XNode.NodePort> dynamicPorts, SerializedProperty arrayData, Type type, SerializedObject serializedObject, XNode.NodePort.IO io, XNode.Node.ConnectionType connectionType, XNode.Node.TypeConstraint typeConstraint, Action<ReorderableList> onCreation) {

--- a/Scripts/Editor/NodeEditorGUILayout.cs
+++ b/Scripts/Editor/NodeEditorGUILayout.cs
@@ -312,6 +312,8 @@ namespace XNodeEditor {
             }).Where(x => x.port != null);
             List<XNode.NodePort> dynamicPorts = indexedPorts.OrderBy(x => x.index).Select(x => x.port).ToList();
 
+            node.UpdatePorts();
+            
             ReorderableList list = null;
             Dictionary<string, ReorderableList> rlc;
             if (reorderableListCache.TryGetValue(serializedObject.targetObject, out rlc)) {
@@ -327,7 +329,6 @@ namespace XNodeEditor {
             list.list = dynamicPorts;
             list.DoLayoutList();
             
-            node.UpdatePorts();
         }
 
         private static ReorderableList CreateReorderableList(string fieldName, List<XNode.NodePort> dynamicPorts, SerializedProperty arrayData, Type type, SerializedObject serializedObject, XNode.NodePort.IO io, XNode.Node.ConnectionType connectionType, XNode.Node.TypeConstraint typeConstraint, Action<ReorderableList> onCreation) {

--- a/Scripts/Editor/NodeEditorGUILayout.cs
+++ b/Scripts/Editor/NodeEditorGUILayout.cs
@@ -340,7 +340,7 @@ namespace XNodeEditor {
             list.drawElementCallback =
                 (Rect rect, int index, bool isActive, bool isFocused) => {
                     XNode.NodePort port = node.GetPort(fieldName + " " + index);
-                    if (hasArrayData) {
+                    if (hasArrayData && arrayData.propertyType != SerializedPropertyType.String) {
                         if (arrayData.arraySize <= index) {
                             EditorGUI.LabelField(rect, "Array[" + index + "] data out of range");
                             return;
@@ -468,7 +468,7 @@ namespace XNodeEditor {
                         EditorUtility.SetDirty(node);
                     }
 
-                    if (hasArrayData) {
+                    if (hasArrayData && arrayData.propertyType != SerializedPropertyType.String) {
                         if (arrayData.arraySize <= index) {
                             Debug.LogWarning("Attempted to remove array index " + index + " where only " + arrayData.arraySize + " exist - Skipped");
                             Debug.Log(rl.list[0]);

--- a/Scripts/Node.cs
+++ b/Scripts/Node.cs
@@ -123,7 +123,7 @@ namespace XNode {
             Init();
         }
 
-        /// <summary> Update all ports to reflect class fields. This happens automatically on enable or on redrawing the list of ports. </summary>
+        /// <summary> Update static ports and dynamic ports managed by DynamicPortLists to reflect class fields. This happens automatically on enable or on redrawing a dynamic port list. </summary>
         public void UpdatePorts() {
             NodeDataCache.UpdatePorts(this, ports);
         }

--- a/Scripts/Node.cs
+++ b/Scripts/Node.cs
@@ -119,12 +119,12 @@ namespace XNode {
         protected void OnEnable() {
             if (graphHotfix != null) graph = graphHotfix;
             graphHotfix = null;
-            UpdateStaticPorts();
+            UpdatePorts();
             Init();
         }
 
-        /// <summary> Update static ports to reflect class fields. This happens automatically on enable. </summary>
-        public void UpdateStaticPorts() {
+        /// <summary> Update all ports to reflect class fields. This happens automatically on enable or on redrawing the list of ports. </summary>
+        public void UpdatePorts() {
             NodeDataCache.UpdatePorts(this, ports);
         }
 

--- a/Scripts/NodeDataCache.cs
+++ b/Scripts/NodeDataCache.cs
@@ -9,7 +9,7 @@ namespace XNode {
         private static PortDataCache portDataCache;
         private static bool Initialized { get { return portDataCache != null; } }
 
-        /// <summary> Update static and dynamic ports managed by DynamicPortLists to reflect class fields. </summary>
+        /// <summary> Update static ports and dynamic ports managed by DynamicPortLists to reflect class fields. </summary>
         public static void UpdatePorts(Node node, Dictionary<string, NodePort> ports) {
             if (!Initialized) BuildCache();
 

--- a/Scripts/NodePort.cs
+++ b/Scripts/NodePort.cs
@@ -19,10 +19,6 @@ namespace XNode {
             }
         }
 
-        // public IO direction { get { return _direction; } }
-        // public Node.ConnectionType connectionType { get { return _connectionType; } }
-        // public Node.TypeConstraint typeConstraint { get { return _typeConstraint; } }
-
         public IO direction { 
             get { return _direction; }
             internal set { _direction = value; }

--- a/Scripts/NodePort.cs
+++ b/Scripts/NodePort.cs
@@ -19,9 +19,22 @@ namespace XNode {
             }
         }
 
-        public IO direction { get { return _direction; } }
-        public Node.ConnectionType connectionType { get { return _connectionType; } }
-        public Node.TypeConstraint typeConstraint { get { return _typeConstraint; } }
+        // public IO direction { get { return _direction; } }
+        // public Node.ConnectionType connectionType { get { return _connectionType; } }
+        // public Node.TypeConstraint typeConstraint { get { return _typeConstraint; } }
+
+        public IO direction { 
+            get { return _direction; }
+            internal set { _direction = value; }
+        }
+        public Node.ConnectionType connectionType {
+            get { return _connectionType; }
+            internal set { _connectionType = value; }
+        }
+        public Node.TypeConstraint typeConstraint {
+            get { return _typeConstraint; }
+            internal set { _typeConstraint = value; }
+        }
 
         /// <summary> Is this port connected to anytihng? </summary>
         public bool IsConnected { get { return connections.Count != 0; } }


### PR DESCRIPTION
Fixes #218 -- perhaps. This pull request contains an example fix for the issue. The node cache's "update ports" method is extended to take dynamic ports into account, and this is also invoked whenever a list of dynamic ports is redrawn. There's probably a more efficient way to do it, but it gets the job done and fixes any and all issues outlined before.

Note that I've not tested it much (if only we had a test suite of some sort, haha), and especially not with lists of dynamic ports without an array/list backing value. I still don't see the point of those and they don't seem to work half the time.

Please have a look and maybe check it out. I'm not sure if it's exactly what it should be.

No fancy C# 6/7 features used, so this should be as backwards-compatible as necessary.