### PR TITLE
More OdinInspector support in xNode editors

### DIFF
--- a/Scripts/Editor/GraphAndNodeEditor.cs
+++ b/Scripts/Editor/GraphAndNodeEditor.cs
@@ -1,13 +1,24 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Reflection;
-using UnityEditor;
+﻿using UnityEditor;
 using UnityEngine;
+#if ODIN_INSPECTOR
+using Sirenix.OdinInspector.Editor;
+using Sirenix.Utilities;
+using Sirenix.Utilities.Editor;
+#endif
 
 namespace XNodeEditor {
     /// <summary> Override graph inspector to show an 'Open Graph' button at the top </summary>
     [CustomEditor(typeof(XNode.NodeGraph), true)]
+#if ODIN_INSPECTOR
+    public class GlobalGraphEditor : OdinEditor {
+        public override void OnInspectorGUI() {
+            if (GUILayout.Button("Edit graph", GUILayout.Height(40))) {
+                NodeEditorWindow.Open(serializedObject.targetObject as XNode.NodeGraph);
+            }
+            base.OnInspectorGUI();
+        }
+    }
+#else
     public class GlobalGraphEditor : Editor {
         public override void OnInspectorGUI() {
             serializedObject.Update();
@@ -24,8 +35,21 @@ namespace XNodeEditor {
             serializedObject.ApplyModifiedProperties();
         }
     }
+#endif
 
     [CustomEditor(typeof(XNode.Node), true)]
+#if ODIN_INSPECTOR
+    public class GlobalNodeEditor : OdinEditor {
+        public override void OnInspectorGUI() {
+            if (GUILayout.Button("Edit graph", GUILayout.Height(40))) {
+                SerializedProperty graphProp = serializedObject.FindProperty("graph");
+                NodeEditorWindow w = NodeEditorWindow.Open(graphProp.objectReferenceValue as XNode.NodeGraph);
+                w.Home(); // Focus selected node
+            }
+            base.OnInspectorGUI();
+        }
+    }
+#else
     public class GlobalNodeEditor : Editor {
         public override void OnInspectorGUI() {
             serializedObject.Update();
@@ -45,4 +69,5 @@ namespace XNodeEditor {
             serializedObject.ApplyModifiedProperties();
         }
     }
+#endif
 }

--- a/Scripts/Editor/NodeEditor.cs
+++ b/Scripts/Editor/NodeEditor.cs
@@ -21,7 +21,7 @@ namespace XNodeEditor {
         public readonly static Dictionary<XNode.NodePort, Vector2> portPositions = new Dictionary<XNode.NodePort, Vector2>();
 
 #if ODIN_INSPECTOR
-        internal static bool inNodeEditor = false;
+        protected internal static bool inNodeEditor = false;
 #endif
 
         public virtual void OnHeaderGUI() {


### PR DESCRIPTION
1. NodeEditor's inNodeEditor is now protected so that Child classes can access it regardless of its assembly.
2. GraphAndNodeEditor (the inspector) shows the big button added by #219 without breaking Odin's inspector functionalities.
3. This is a minor change, but it looked like some of the imports in GraphAndNodeEditor weren't used, so I removed them.