### PR TITLE
Added a virtual OnRename function to base nodes, triggered when a node gets renamed.

### DIFF
--- a/Scripts/Editor/NodeEditor.cs
+++ b/Scripts/Editor/NodeEditor.cs
@@ -129,33 +129,14 @@ namespace XNodeEditor {
         public void Rename(string newName) {
             if (newName == null || newName.Trim() == "") newName = NodeEditorUtilities.NodeDefaultName(target.GetType());
             target.name = newName;
-            TriggerRenameNotifications(target);
+            OnRename();
+            AssetDatabase.ImportAsset(AssetDatabase.GetAssetPath(target));
         }
         
-        /// <summary>
-        /// Triggers OnRename on all nodes in the graph after a node's name changes,
-        /// reimporting asset files for all subsequently renamed nodes.
-        /// </summary>
-        public static void TriggerRenameNotifications(XNode.Node renamedNode) {
-            List<XNode.Node> graphNodes = renamedNode.graph.nodes;
-            string[] oldNodeNames = new string[graphNodes.Count];
-            // Notify all nodes, allow them to further change names accordingly
-            for (int i = 0; i < graphNodes.Count; i++) {
-                XNode.Node node = graphNodes[i];
-                oldNodeNames[i] = node.name;
-                node.OnRename(renamedNode);
-            }
-
-            // After all user-driven modifications have been resolved, update all assets whose node names have changed
-            // (And always reimport the node which got renamed in the first place)
-            for (int i = 0; i < graphNodes.Count; i++) {
-                if (graphNodes[i] == renamedNode || graphNodes[i].name != oldNodeNames[i]) {
-                    AssetDatabase.ImportAsset(AssetDatabase.GetAssetPath(graphNodes[i]));
-                }
-            }
-        }
+        /// <summary> Called after this node's name has changed. </summary>
+        public virtual void OnRename() { }
         
-
+        
         [AttributeUsage(AttributeTargets.Class)]
         public class CustomNodeEditorAttribute : Attribute,
         XNodeEditor.Internal.NodeEditorBase<NodeEditor, NodeEditor.CustomNodeEditorAttribute, XNode.Node>.INodeEditorAttrib {

--- a/Scripts/Editor/RenamePopup.cs
+++ b/Scripts/Editor/RenamePopup.cs
@@ -49,7 +49,7 @@ namespace XNodeEditor {
             if (input == null || input.Trim() == "") {
                 if (GUILayout.Button("Revert to default") || (e.isKey && e.keyCode == KeyCode.Return)) {
                     target.name = NodeEditorUtilities.NodeDefaultName(target.GetType());
-                    AssetDatabase.ImportAsset(AssetDatabase.GetAssetPath(target));
+                    NodeEditor.TriggerRenameNotifications((XNode.Node)target);
                     Close();
 					target.TriggerOnValidate();
                 }
@@ -58,7 +58,7 @@ namespace XNodeEditor {
             else {
                 if (GUILayout.Button("Apply") || (e.isKey && e.keyCode == KeyCode.Return)) {
                     target.name = input;
-                    AssetDatabase.ImportAsset(AssetDatabase.GetAssetPath(target));
+                    NodeEditor.TriggerRenameNotifications((XNode.Node)target);
                     Close();
 					target.TriggerOnValidate();
                 }

--- a/Scripts/Editor/RenamePopup.cs
+++ b/Scripts/Editor/RenamePopup.cs
@@ -49,7 +49,8 @@ namespace XNodeEditor {
             if (input == null || input.Trim() == "") {
                 if (GUILayout.Button("Revert to default") || (e.isKey && e.keyCode == KeyCode.Return)) {
                     target.name = NodeEditorUtilities.NodeDefaultName(target.GetType());
-                    NodeEditor.TriggerRenameNotifications((XNode.Node)target);
+                    NodeEditor.GetEditor((XNode.Node)target, NodeEditorWindow.current).OnRename();
+                    AssetDatabase.ImportAsset(AssetDatabase.GetAssetPath(target));
                     Close();
 					target.TriggerOnValidate();
                 }
@@ -58,7 +59,8 @@ namespace XNodeEditor {
             else {
                 if (GUILayout.Button("Apply") || (e.isKey && e.keyCode == KeyCode.Return)) {
                     target.name = input;
-                    NodeEditor.TriggerRenameNotifications((XNode.Node)target);
+                    NodeEditor.GetEditor((XNode.Node)target, NodeEditorWindow.current).OnRename();
+                    AssetDatabase.ImportAsset(AssetDatabase.GetAssetPath(target));
                     Close();
 					target.TriggerOnValidate();
                 }

--- a/Scripts/Node.cs
+++ b/Scripts/Node.cs
@@ -254,9 +254,6 @@ namespace XNode {
         /// <summary> Called after a connection is removed from this port </summary>
         /// <param name="port">Output or Input</param>
         public virtual void OnRemoveConnection(NodePort port) { }
-        
-        /// <summary> Called after a node's name has changed. </summary>
-        public virtual void OnRename(Node node) { }
 
         /// <summary> Disconnect everything from this node </summary>
         public void ClearConnections() {

--- a/Scripts/Node.cs
+++ b/Scripts/Node.cs
@@ -254,6 +254,9 @@ namespace XNode {
         /// <summary> Called after a connection is removed from this port </summary>
         /// <param name="port">Output or Input</param>
         public virtual void OnRemoveConnection(NodePort port) { }
+        
+        /// <summary> Called after a node's name has changed. </summary>
+        public virtual void OnRename(Node node) { }
 
         /// <summary> Disconnect everything from this node </summary>
         public void ClearConnections() {


### PR DESCRIPTION
```csharp
public class TargetNode : Node {
	public override void OnRename(Node node) {
		if (node == this) DoSomethingElse();
	}

	[...]
}
```

Having an `OnRename` "event" is very useful when you want to validate node name changes on a case-by-case basis, or want to notify other nodes when a node's name changes (e.g. when you want your outputs to display the names of the currently connected input nodes).

Given that it's possible for an `OnRename` function to change the node's name subsequently (or even rename another node, I guess), asset reimports are done on a subsequent step after all `OnRename`s in the graph have been processed, for all nodes that have had their names changed. This enforces the equivalence between node names and asset names that we have right now.