### PR TITLE
Add a dragthreshold to better distunguish right clicks and right drags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ sysinfo.txt
 .git.meta
 .gitignore.meta
 .gitattributes.meta
+
+# OS X only:
+.DS_Store

--- a/Scripts/Editor/NodeEditorAction.cs
+++ b/Scripts/Editor/NodeEditorAction.cs
@@ -32,6 +32,7 @@ namespace XNodeEditor {
         private Rect selectionBox;
         private bool isDoubleClick = false;
         private Vector2 lastMousePosition;
+        private float dragThreshold = 1f;
 
         public void Controls() {
             wantsMouseMove = true;
@@ -134,8 +135,11 @@ namespace XNodeEditor {
                             Repaint();
                         }
                     } else if (e.button == 1 || e.button == 2) {
-                        panOffset += e.delta * zoom;
-                        isPanning = true;
+                        //check drag threshold for larger screens
+                        if (e.delta.magnitude > dragThreshold) {
+                            panOffset += e.delta * zoom;
+                            isPanning = true;
+                        }
                     }
                     break;
                 case EventType.MouseDown:

--- a/Scripts/Editor/NodeEditorWindow.cs
+++ b/Scripts/Editor/NodeEditorWindow.cs
@@ -78,6 +78,8 @@ namespace XNodeEditor {
             current = this;
             ValidateGraphEditor();
             if (graphEditor != null && NodeEditorPreferences.GetSettings().autoSave) AssetDatabase.SaveAssets();
+
+            dragThreshold = Screen.width / 1000f;
         }
 
         [InitializeOnLoadMethod]

--- a/Scripts/Editor/NodeEditorWindow.cs
+++ b/Scripts/Editor/NodeEditorWindow.cs
@@ -79,7 +79,7 @@ namespace XNodeEditor {
             ValidateGraphEditor();
             if (graphEditor != null && NodeEditorPreferences.GetSettings().autoSave) AssetDatabase.SaveAssets();
 
-            dragThreshold = Screen.width / 1000f;
+            dragThreshold = Math.Max(1f, Screen.width / 1000f);
         }
 
         [InitializeOnLoadMethod]


### PR DESCRIPTION
This adds a drag threshold so that you can scroll around and right click the graph editor more reliably. I use a retina screen and it was very unreliable without this change. Discussed in issue #228 