### PR TITLE
Allow dynamic ports defined as arrays/lists to connect to ports of their elements' types

### DIFF
--- a/Scripts/NodeDataCache.cs
+++ b/Scripts/NodeDataCache.cs
@@ -76,11 +76,26 @@ namespace XNode {
                 NodePort backingPort = staticPorts[backingPortName];
                 
                 // Update port constraints. Creating a new port instead will break the editor, mandating the need for setters.
-                listPort.ValueType = backingPort.ValueType;
+                listPort.ValueType = GetBackingValueType(backingPort.ValueType);
                 listPort.direction = backingPort.direction;
                 listPort.connectionType = backingPort.connectionType;
                 listPort.typeConstraint = backingPort.typeConstraint;
             }
+        }
+
+        /// <summary>
+        /// Extracts the underlying types from arrays and lists, the only collections for dynamic port lists
+        /// currently supported. If the given type is not applicable (i.e. if the dynamic list port was not
+        /// defined as an array or a list), returns the given type itself. 
+        /// </summary>
+        private static System.Type GetBackingValueType(System.Type portValType) {
+            if (portValType.HasElementType) {
+                return portValType.GetElementType();
+            }
+            if (portValType.IsGenericType && portValType.GetGenericTypeDefinition() == typeof(List<>)) {
+                return portValType.GetGenericArguments()[0];
+            }
+            return portValType;
         }
 
         /// <summary>Returns true if the given port is in a dynamic port list.</summary>


### PR DESCRIPTION
Second time's the charm...

In short, this commit allows the following:
![image](https://user-images.githubusercontent.com/17273782/73614526-cf935780-45f7-11ea-878b-8b580dae384c.png)

```csharp
/// "SOURCE"
[Output(typeConstraint = TypeConstraint.Strict, dynamicPortList = true, connectionType = ConnectionType.Override)]
public string[] stringArray;

[Output(typeConstraint = TypeConstraint.Strict, dynamicPortList = true, connectionType = ConnectionType.Override)]
public List<string> stringList;

/// "TARGET"
[Input(typeConstraint = TypeConstraint.Strict, dynamicPortList = true)]
public string[] stringArray;

[Input(typeConstraint = TypeConstraint.Strict)]
public string stringInput1;

[Input(typeConstraint = TypeConstraint.Strict, dynamicPortList = true)]
public List<string> stringInput2;
```

**Why?** Because it makes no sense that a dynamic port list defined as a `string[]` is expected to actually be a list of _lists of strings_ and to have each of its elements only allow connections to a `string[]` instead of a `string` (when the Strict constraint is imposed). This is counterintuitive, especially given that the node editor already draws a dynamic port list of type `string[]` with each of its elements being a `string`. Thus -- with the node editors as-is -- you get an intuitive and simple correspondence between port "stringArray 0" and the value of `stringArray[0]` which has been set in the editor.

Without this fix though, your nice `string` ports inside a list/array that you've set in the editor can't be connected to other `string`s, because every such port, despite being drawn as a `string` and intuitively bound to a `string`, considers itself of type `string[]`. And this is what this PR fixes.

(The above applies to any type when dynamic port lists are considered.)