### PR TITLE
Skip Microsoft assemblies while building node cache

### DIFF
--- a/Scripts/NodeDataCache.cs
+++ b/Scripts/NodeDataCache.cs
@@ -122,7 +122,6 @@ namespace XNode {
                     case "UnityEngine":
                     case "System":
                     case "mscorlib":
-                    case "Unity":
                     case "Microsoft":
                         continue;
                     default:

--- a/Scripts/NodeDataCache.cs
+++ b/Scripts/NodeDataCache.cs
@@ -122,6 +122,8 @@ namespace XNode {
                     case "UnityEngine":
                     case "System":
                     case "mscorlib":
+                    case "Unity":
+                    case "Microsoft":
                         continue;
                     default:
                         nodeTypes.AddRange(assembly.GetTypes().Where(t => !t.IsAbstract && baseType.IsAssignableFrom(t)).ToArray());


### PR DESCRIPTION
After upgrading to 2019.3 I started getting an error that would crash the node editor and corrupt the asset file. This change fixes it. Basically `Microsoft.Win32.Primitives` Assembly is causing problems. I also noticed many Unity packages (like `Unity.TextMeshPro` for example) are checked and they should not be checked.