### PR TITLE
String format fix and simplified assembly skip

### DIFF
--- a/Scripts/Node.cs
+++ b/Scripts/Node.cs
@@ -377,8 +377,7 @@ namespace XNode {
             public void OnAfterDeserialize() {
                 this.Clear();
 
-                if (keys.Count != values.Count)
-                {
+                if (keys.Count != values.Count) {
                     var msg = string.Format(
                         XNodeRuntimeConstants.MISMATCHED_KEYS_TO_VALUES_EXCEPTION_MESSAGE,
                         keys.Count,

--- a/Scripts/Node.cs
+++ b/Scripts/Node.cs
@@ -378,7 +378,13 @@ namespace XNode {
                 this.Clear();
 
                 if (keys.Count != values.Count)
-                    throw new System.Exception("there are " + keys.Count + " keys and " + values.Count + " values after deserialization. Make sure that both key and value types are serializable.");
+                {
+                    var msg = string.Format(
+                        XNodeRuntimeConstants.MISMATCHED_KEYS_TO_VALUES_EXCEPTION_MESSAGE,
+                        keys.Count,
+                        values.Count);
+                    throw new Exception(msg);
+                }
 
                 for (int i = 0; i < keys.Count; i++)
                     this.Add(keys[i], values[i]);

--- a/Scripts/NodeDataCache.cs
+++ b/Scripts/NodeDataCache.cs
@@ -68,14 +68,14 @@ namespace XNode {
                     ports.Add(staticPort.fieldName, port);
                 }
             }
-            
+
             // Finally, make sure dynamic list port settings correspond to the settings of their "backing port"
             foreach (NodePort listPort in dynamicListPorts) {
                 // At this point we know that ports here are dynamic list ports
                 // which have passed name/"backing port" checks, ergo we can proceed more safely.
-                string backingPortName = listPort.fieldName.Split(' ')[0];
+                string backingPortName = listPort.fieldName.Split(' ') [0];
                 NodePort backingPort = staticPorts[backingPortName];
-                
+
                 // Update port constraints. Creating a new port instead will break the editor, mandating the need for setters.
                 listPort.ValueType = GetBackingValueType(backingPort.ValueType);
                 listPort.direction = backingPort.direction;
@@ -94,7 +94,7 @@ namespace XNode {
                 return portValType.GetElementType();
             }
             if (portValType.IsGenericType && portValType.GetGenericTypeDefinition() == typeof(List<>)) {
-                return portValType.GetGenericArguments()[0];
+                return portValType.GetGenericArguments() [0];
             }
             return portValType;
         }
@@ -106,19 +106,19 @@ namespace XNode {
             // Thus, we need to check for attributes... (but at least we don't need to look at all fields this time)
             string[] fieldNameParts = port.fieldName.Split(' ');
             if (fieldNameParts.Length != 2) return false;
-            
+
             FieldInfo backingPortInfo = port.node.GetType().GetField(fieldNameParts[0]);
             if (backingPortInfo == null) return false;
-            
+
             object[] attribs = backingPortInfo.GetCustomAttributes(true);
             return attribs.Any(x => {
                 Node.InputAttribute inputAttribute = x as Node.InputAttribute;
                 Node.OutputAttribute outputAttribute = x as Node.OutputAttribute;
                 return inputAttribute != null && inputAttribute.dynamicPortList ||
-                       outputAttribute != null && outputAttribute.dynamicPortList;
+                    outputAttribute != null && outputAttribute.dynamicPortList;
             });
         }
-        
+
         /// <summary> Cache node types </summary>
         private static void BuildCache() {
             portDataCache = new PortDataCache();
@@ -127,12 +127,10 @@ namespace XNode {
             Assembly[] assemblies = AppDomain.CurrentDomain.GetAssemblies();
 
             // Loop through assemblies and add node types to list
-            foreach (Assembly assembly in assemblies)
-            {
+            foreach (Assembly assembly in assemblies) {
                 // Skip certain dlls to improve performance
                 string assemblyName = assembly.GetName().Name;
-                if (!XNodeRuntimeConstants.IGNORE_ASSEMBLY_PREFIXES.Any(x => assemblyName.StartsWith(x)))
-                {
+                if (!XNodeRuntimeConstants.IGNORE_ASSEMBLY_PREFIXES.Any(x => assemblyName.StartsWith(x))) {
                     IEnumerable<Type> foundNodeTypes = assembly.GetTypes()
                         .Where(t => !t.IsAbstract && baseType.IsAssignableFrom(t));
                     nodeTypes.AddRange(foundNodeTypes);
@@ -194,8 +192,7 @@ namespace XNode {
             public void OnAfterDeserialize() {
                 this.Clear();
 
-                if (keys.Count != values.Count)
-                {
+                if (keys.Count != values.Count) {
                     var msg = string.Format(
                         XNodeRuntimeConstants.MISMATCHED_KEYS_TO_VALUES_EXCEPTION_MESSAGE,
                         keys.Count,

--- a/Scripts/XNodeRuntimeConstants.cs
+++ b/Scripts/XNodeRuntimeConstants.cs
@@ -1,0 +1,33 @@
+namespace XNode
+{
+    /// <summary>
+    /// A helper class containing shared constants.
+    /// </summary>
+	public static class XNodeRuntimeConstants
+	{
+        // Exceptions
+		public const string MISMATCHED_KEYS_TO_VALUES_EXCEPTION_MESSAGE =
+			"There are {0} keys and {1} values after deserialization. " +
+			"Make sure that both key and value types are serializable.";
+
+        // Reflection
+
+        /// <summary>
+        /// A collection of assembly prefixes that should not be reflected for derived node types.
+        /// </summary>
+        public static string[] IGNORE_ASSEMBLY_PREFIXES =
+        {
+            "ExCSS",
+            "Microsoft",
+            "Mono",
+            "netstandard",
+            "mscorlib",
+            "nunit",
+            "SyntaxTree",
+            "System",
+            "Unity",
+            "UnityEditor",
+            "UnityEngine"
+        };
+	}
+}

--- a/Scripts/XNodeRuntimeConstants.cs
+++ b/Scripts/XNodeRuntimeConstants.cs
@@ -25,7 +25,6 @@ namespace XNode
             "nunit",
             "SyntaxTree",
             "System",
-            "Unity",
             "UnityEditor",
             "UnityEngine"
         };

--- a/Scripts/XNodeRuntimeConstants.cs
+++ b/Scripts/XNodeRuntimeConstants.cs
@@ -1,22 +1,19 @@
-namespace XNode
-{
+namespace XNode {
     /// <summary>
     /// A helper class containing shared constants.
     /// </summary>
-	public static class XNodeRuntimeConstants
-	{
+    public static class XNodeRuntimeConstants {
         // Exceptions
-		public const string MISMATCHED_KEYS_TO_VALUES_EXCEPTION_MESSAGE =
-			"There are {0} keys and {1} values after deserialization. " +
-			"Make sure that both key and value types are serializable.";
+        public const string MISMATCHED_KEYS_TO_VALUES_EXCEPTION_MESSAGE =
+            "There are {0} keys and {1} values after deserialization. " +
+            "Make sure that both key and value types are serializable.";
 
         // Reflection
 
         /// <summary>
         /// A collection of assembly prefixes that should not be reflected for derived node types.
         /// </summary>
-        public static string[] IGNORE_ASSEMBLY_PREFIXES =
-        {
+        public static string[] IGNORE_ASSEMBLY_PREFIXES = {
             "ExCSS",
             "Microsoft",
             "Mono",
@@ -28,5 +25,5 @@ namespace XNode
             "UnityEditor",
             "UnityEngine"
         };
-	}
+    }
 }

--- a/Scripts/XNodeRuntimeConstants.cs.meta
+++ b/Scripts/XNodeRuntimeConstants.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cf01fc218f8f12d4aa557c9799289063
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary

This PR adds a fix in `Node.cs` for missing arguments passed to `string.Format` message for an exception by adding the expected arguments. I also noticed that the same exception logic and message is being thrown in `NodeDataCache.cs` so I moved the exception message to a constants class so that updating the message would take place in both classes and duplicated the formatting for how the exception was thrown in both files.

I also simplified the logic for how assemblies are skipped when discovering nodes types by creating a constant array of assembly prefixes that should be skipped and compare the assembly name to those to see if it should be skipped. This significantly reduce the logic flow for that method.

## Testing

* Ensure that Nodes can still be discovered by opening any graph and attempt to add a Node.

## Changes
Fixed missing format arguments for exception

* Added missing string format arguments used for exception
* Moved duplicate exception message to XNodeRuntimeConstants class
* Modified NodeDataCache deserialization exception thrown to be the same format as Node

Simplified logic for discovering node types

* Simplified the reflection logic used to discover node types by creating a constant array of assembly prefixes to ignore and then checking to see if discovered assembly names begin with those prefixes, and if they do skip checking them for derived node types. Added additional common assembly prefixes that Unity loads into memory that would not contain Node types.