### PR TITLE
Added fix for duplicate node fields found

### DIFF
--- a/Scripts/NodeDataCache.cs
+++ b/Scripts/NodeDataCache.cs
@@ -156,7 +156,14 @@ namespace XNode {
             // GetFields doesnt return inherited private fields, so walk through base types and pick those up
             System.Type tempType = nodeType;
             while ((tempType = tempType.BaseType) != typeof(XNode.Node)) {
-                fieldInfo.AddRange(tempType.GetFields(BindingFlags.NonPublic | BindingFlags.Instance));
+                FieldInfo[] parentFields = tempType.GetFields(BindingFlags.NonPublic | BindingFlags.Instance);
+                for (int i = 0; i < parentFields.Length; i++) {
+                    // Ensure that we do not already have a member with this type and name
+                    FieldInfo parentField = parentFields[i];
+                    if (fieldInfo.TrueForAll(x => x.Name != parentField.Name)) {
+                        fieldInfo.Add(parentField);
+                    }
+                }
             }
             return fieldInfo;
         }


### PR DESCRIPTION
## Summary

Recently I ran into this error when refactoring some of the common fields in my node types into a base class used by several nodes.

```
ArgumentException: An item with the same key has already been added. Key: _childFolders
System.Collections.Generic.Dictionary`2[TKey,TValue].TryInsert (TKey key, TValue value, System.Collections.Generic.InsertionBehavior behavior) (at <437ba245d8404784b9fbab9b439ac908>:0)
System.Collections.Generic.Dictionary`2[TKey,TValue].Add (TKey key, TValue value) (at <437ba245d8404784b9fbab9b439ac908>:0)
XNode.NodeDataCache.UpdatePorts (XNode.Node node, System.Collections.Generic.Dictionary`2[TKey,TValue] ports) (at Library/PackageCache/com.jeffcampbellmakesgames.xnode@f3d1ad46d8e4f559706b2d6c55460c538c0efd19/xNode/Scripts/Cache/NodeDataCache.cs:80)
XNode.Node.UpdatePorts () (at Library/PackageCache/com.jeffcampbellmakesgames.xnode@f3d1ad46d8e4f559706b2d6c55460c538c0efd19/xNode/Scripts/Node.cs:193)
XNode.Node.OnEnable () (at Library/PackageCache/com.jeffcampbellmakesgames.xnode@f3d1ad46d8e4f559706b2d6c55460c538c0efd19/xNode/Scripts/Node.cs:183)
```

Debugging this in the editor, the issue appeared to be caused by duplicate fields returned by `NodeDataCache.GetNodeFields` for a derived node type from this abstract node type as the first `GetFields` call made returned both the derived and base type private and public instance fields. This resulted in the pending iteration up through the base class to also grab the same base abstract type fields again. Thus, when the node is created and its ports are being updated it errors on adding these duplicate fields.

![image](https://user-images.githubusercontent.com/1663648/75590622-02f1c680-5a7e-11ea-8a6b-f7f7a2069252.png)

This issue may not have been seen or reported before as the duplicate fields are protected, which is considered public in the context of the class internals. In any case, this PR addresses that in a way that should be backwards compatible by ensuring that we do not add any `FieldInfo` instances that were already discovered in the first `GetFields` call for this type of situation.

## Testing

Using the example code below with this fix, it should be possible to add the node `DerivedNodeType` to a graph without this error on Unity 2019.3 (I'm not certain for older versions of Unity). Without this fix, it should result in the error at the top of this PR.

**Example code for reference**
```
internal sealed class DerivedNodeType : BaseNodeType 
{
}

internal abstract class BaseNodeType : Node
{
	[Input(typeConstraint = TypeConstraint.Strict)]
	[SerializeField]
	protected string[] _childFolders;
}
```

## Changes
* Added fix for duplicate node fields found while iterating through base fields; on 2019.3 using .Net 20 getting the fields of the node type will return all base type fields as well. This results in the iteration up through the base classes and adding their instance fields resulting in duplicates which causes errors on node creation when assigning port information.