### PR TITLE
Added fix for rename bug with v2 AssetDatabase

### DIFF
--- a/Scripts/Editor/GraphRenameFixAssetProcessor.cs
+++ b/Scripts/Editor/GraphRenameFixAssetProcessor.cs
@@ -1,8 +1,7 @@
 ﻿using UnityEditor;
 using XNode;
 
-namespace XNodeEditor
-{
+namespace XNodeEditor {
     /// <summary>
     /// This asset processor resolves an issue with the new v2 AssetDatabase system present on 2019.3 and later. When
     /// renaming a <see cref="XNode.NodeGraph"/> asset, it appears that sometimes the v2 AssetDatabase will swap which asset
@@ -11,23 +10,19 @@ namespace XNodeEditor
     /// finds a case where a <see cref="XNode.Node"/> has been made the main asset it will swap it back to being a sub-asset
     /// and rename the node to the default name for that node type.
     /// </summary>
-    internal sealed class GraphRenameFixAssetProcessor : AssetPostprocessor
-    {
+    internal sealed class GraphRenameFixAssetProcessor : AssetPostprocessor {
         private static void OnPostprocessAllAssets(
             string[] importedAssets,
             string[] deletedAssets,
             string[] movedAssets,
-            string[] movedFromAssetPaths)
-        {
-            for (int i = 0; i < movedAssets.Length; i++)
-            {
+            string[] movedFromAssetPaths) {
+            for (int i = 0; i < movedAssets.Length; i++) {
                 Node nodeAsset = AssetDatabase.LoadMainAssetAtPath(movedAssets[i]) as Node;
 
                 // If the renamed asset is a node graph, but the v2 AssetDatabase has swapped a sub-asset node to be its
                 // main asset, reset the node graph to be the main asset and rename the node asset back to its default
                 // name.
-                if (nodeAsset != null && AssetDatabase.IsMainAsset(nodeAsset))
-                {
+                if (nodeAsset != null && AssetDatabase.IsMainAsset(nodeAsset)) {
                     AssetDatabase.SetMainObject(nodeAsset.graph, movedAssets[i]);
                     AssetDatabase.ImportAsset(movedAssets[i]);
 

--- a/Scripts/Editor/GraphRenameFixAssetProcessor.cs
+++ b/Scripts/Editor/GraphRenameFixAssetProcessor.cs
@@ -1,0 +1,40 @@
+﻿using UnityEditor;
+using XNode;
+
+namespace XNodeEditor
+{
+    /// <summary>
+    /// This asset processor resolves an issue with the new v2 AssetDatabase system present on 2019.3 and later. When
+    /// renaming a <see cref="XNode.NodeGraph"/> asset, it appears that sometimes the v2 AssetDatabase will swap which asset
+    /// is the main asset (present at top level) between the <see cref="XNode.NodeGraph"/> and one of its <see cref="XNode.Node"/>
+    /// sub-assets. As a workaround until Unity fixes this, this asset processor checks all renamed assets and if it
+    /// finds a case where a <see cref="XNode.Node"/> has been made the main asset it will swap it back to being a sub-asset
+    /// and rename the node to the default name for that node type.
+    /// </summary>
+    internal sealed class GraphRenameFixAssetProcessor : AssetPostprocessor
+    {
+        private static void OnPostprocessAllAssets(
+            string[] importedAssets,
+            string[] deletedAssets,
+            string[] movedAssets,
+            string[] movedFromAssetPaths)
+        {
+            for (int i = 0; i < movedAssets.Length; i++)
+            {
+                Node nodeAsset = AssetDatabase.LoadMainAssetAtPath(movedAssets[i]) as Node;
+
+                // If the renamed asset is a node graph, but the v2 AssetDatabase has swapped a sub-asset node to be its
+                // main asset, reset the node graph to be the main asset and rename the node asset back to its default
+                // name.
+                if (nodeAsset != null && AssetDatabase.IsMainAsset(nodeAsset))
+                {
+                    AssetDatabase.SetMainObject(nodeAsset.graph, movedAssets[i]);
+                    AssetDatabase.ImportAsset(movedAssets[i]);
+
+                    nodeAsset.name = NodeEditorUtilities.NodeDefaultName(nodeAsset.GetType());
+                    EditorUtility.SetDirty(nodeAsset);
+                }
+            }
+        }
+    }
+}

--- a/Scripts/Editor/GraphRenameFixAssetProcessor.cs.meta
+++ b/Scripts/Editor/GraphRenameFixAssetProcessor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 65da1ff1c50a9984a9c95fd18799e8dd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
This PR fixes an issue where a graph can end up being swapped as the main asset with one of its nodes. Its been referenced and fixes in a few cases before listed below, but only where renaming the node has triggered the bug to occur. I've also been able to reproduce this bug by:

* Creating a new graph.
* Adding a single node.
* Renaming the graph.

It doesn't reproduce the bug for every graph type (the example content doesn't produce this issue), but in my own tool development using xNode it has been reliable.

This should permanently fix that issue since it will check on an asset rename to make sure that the renamed asset is a a Node and set as the main asset. If so, it will swap back  the graph to being the main asset.

**Referenced Issues:**
* https://github.com/Siccity/xNode/issues/235
* https://github.com/Siccity/xNode/issues/185

## Changes
* Added fix for NodeGraph rename bug with v2 AssetDatabase where renaming a graph asset can sometimes result in it being swapped as the main asset with one of the node sub assets.