### PR TITLE
Added NRE check for ValidateGraphEditor

### DIFF
--- a/Scripts/Editor/NodeEditorWindow.cs
+++ b/Scripts/Editor/NodeEditorWindow.cs
@@ -97,7 +97,7 @@ namespace XNodeEditor {
         /// <summary> Make sure the graph editor is assigned and to the right object </summary>
         private void ValidateGraphEditor() {
             NodeGraphEditor graphEditor = NodeGraphEditor.GetEditor(graph, this);
-            if (this.graphEditor != graphEditor) {
+            if (this.graphEditor != graphEditor && graphEditor != null) {
                 this.graphEditor = graphEditor;
                 graphEditor.OnOpen();
             }


### PR DESCRIPTION
## Summary
This PR fixes an issue where some instances of calling `ValidateGraphEditor` would result in an NRE as `NodeGraphEditor.GetEditor` can return a null graph editor instance, swap it with a non-null instance as they wouldn't be equal, and then attempt to call methods on the null instance. The way that I reproduced this issue was on creating a graph in the project window where when the node graph editor window was focused it would result in an NRE.

```
private void OnFocus()
{
	current = this;
	ValidateGraphEditor(); // This instance of calling ValidateGraphEditor resulted in this NRE where `NodeGraphEditor.GetEditor` returns null. 
	if (graphEditor != null && NodeEditorPreferences.GetSettings().autoSave)
	{
		AssetDatabase.SaveAssets();
	}
}
```

## Changes
* Added NRE check to prevent exception when NodeGraphEditor.GetEditor returns null and an existing non-null graph editor is already present.