### PR TITLE
Implemented #242 - Added NodeEditor.OnEnable()

### DIFF
--- a/Scripts/Editor/NodeEditorBase.cs
+++ b/Scripts/Editor/NodeEditorBase.cs
@@ -49,8 +49,14 @@ namespace XNodeEditor.Internal {
 				editor.target = target;
 				editor.serializedObject = new SerializedObject(target);
 				editor.window = window;
+
+				// OnCreate is obsolete - use OnEnable instead
+#pragma warning disable 0618
 				editor.OnCreate();
+#pragma warning restore 0618
+
 				editors.Add(target, editor);
+				editor.OnEnable();
 			}
 			if (editor.target == null) editor.target = target;
 			if (editor.window != window) editor.window = window;
@@ -81,8 +87,17 @@ namespace XNodeEditor.Internal {
 			}
 		}
 
+		/// <summary> Clears stored editors. Called when a new graph opens. Ensures that NodeEditor.OnEnable is called as expected. </summary>
+		public static void ClearCachedEditors() {
+			editors = new Dictionary<K, T>();
+		}
+
 		/// <summary> Called on creation, after references have been set </summary>
+		[Obsolete("OnCreate() is deprecated, please use OnEnable() instead.")]
 		public virtual void OnCreate() { }
+
+		/// <summary> Called when a graph containing the node is opened </summary>
+		public virtual void OnEnable() { }
 
 		public interface INodeEditorAttrib {
 			Type GetInspectedType();

--- a/Scripts/Editor/NodeEditorWindow.cs
+++ b/Scripts/Editor/NodeEditorWindow.cs
@@ -55,6 +55,7 @@ namespace XNodeEditor {
         }
 
         private void OnEnable() {
+            NodeEditor.ClearCachedEditors();
             // Reload portConnectionPoints if there are any
             int length = _references.Length;
             if (length == _rects.Length) {
@@ -193,6 +194,7 @@ namespace XNodeEditor {
             NodeEditorWindow w = GetWindow(typeof(NodeEditorWindow), false, "xNode", true) as NodeEditorWindow;
             w.wantsMouseMove = true;
             w.graph = graph;
+            NodeEditor.ClearCachedEditors();
             return w;
         }
 


### PR DESCRIPTION
To recap Issue #242: XNode's `NodeEditor` does not have an `OnEnable` method like the Unity Editor does. This PR adds an `OnEnable` virtual method to `NodeEditor` and calls it when the editor is instantiated - for instance, when a graph containing the node is opened, or when the graph window switches to a graph containing the node.

I have also deprecated `NodeEditor.OnCreate` call as it has been superseded by `OnEnable`, which has a name more inline with what I assume most developers would expect. Currently `OnCreate` functions identically to `OnEnable`.

I made a major change to the way editors are cached in order to make `OnEnable` work as expected. XNode stores the type and an instance of every `NodeEditor` it can find in `NodeEditorBase`. Keeping the type cached makes sense, as reflection is expensive and it's highly unlikely to change during (Editor) runtime. However, I have added a method that flushes the instance cache (See `ClearCachedEditors`) when called. When a node graph is opened, it is called, and the cache is cleared.  This way the required editors for the graph are instantiated, and their editors' `OnEnable` methods are called.

This is my first every PR on a public repo, I have to admit I'm a little nervous :) I did my best to follow the contribution guidelines, but I saw that `NodeEditorBase` is indented using tabs. I figured I'd leave it alone...