### PR TITLE
[FIX] KeyNotFoundException in NodeEditorGUILayout.DynamicPortList when choosing no to draw all the ports

### DIFF
--- a/Scripts/Editor/NodeEditorGUILayout.cs
+++ b/Scripts/Editor/NodeEditorGUILayout.cs
@@ -371,7 +371,10 @@ namespace XNodeEditor {
                 };
             list.onReorderCallback =
                 (ReorderableList rl) => {
-
+                    bool hasRect = false;
+                    bool hasNewRect = false;
+                    Rect rect = Rect.zero;
+                    Rect newRect = Rect.zero;
                     // Move up
                     if (rl.index > reorderableListIndex) {
                         for (int i = reorderableListIndex; i < rl.index; ++i) {
@@ -380,9 +383,10 @@ namespace XNodeEditor {
                             port.SwapConnections(nextPort);
 
                             // Swap cached positions to mitigate twitching
-                            Rect rect = NodeEditorWindow.current.portConnectionPoints[port];
-                            NodeEditorWindow.current.portConnectionPoints[port] = NodeEditorWindow.current.portConnectionPoints[nextPort];
-                            NodeEditorWindow.current.portConnectionPoints[nextPort] = rect;
+                            hasRect = NodeEditorWindow.current.portConnectionPoints.TryGetValue(port, out rect);
+                            hasNewRect = NodeEditorWindow.current.portConnectionPoints.TryGetValue(nextPort, out newRect);
+                            NodeEditorWindow.current.portConnectionPoints[port] = hasNewRect?newRect:rect;
+                            NodeEditorWindow.current.portConnectionPoints[nextPort] = hasRect?rect:newRect;
                         }
                     }
                     // Move down
@@ -393,9 +397,10 @@ namespace XNodeEditor {
                             port.SwapConnections(nextPort);
 
                             // Swap cached positions to mitigate twitching
-                            Rect rect = NodeEditorWindow.current.portConnectionPoints[port];
-                            NodeEditorWindow.current.portConnectionPoints[port] = NodeEditorWindow.current.portConnectionPoints[nextPort];
-                            NodeEditorWindow.current.portConnectionPoints[nextPort] = rect;
+                            hasRect = NodeEditorWindow.current.portConnectionPoints.TryGetValue(port, out rect);
+                            hasNewRect = NodeEditorWindow.current.portConnectionPoints.TryGetValue(nextPort, out newRect);
+                            NodeEditorWindow.current.portConnectionPoints[port] = hasNewRect?newRect:rect;
+                            NodeEditorWindow.current.portConnectionPoints[nextPort] = hasRect?rect:newRect;
                         }
                     }
                     // Apply changes


### PR DESCRIPTION
Fix a problem when a complex class with optional port drawing is used with NodeEditorGUILayout.DynamicPortList. By having an item that wasn't drawing the port, the method was throwing a KeyNotFoundException when reordering.

The fix detects if there isn't a port when swapping rects.