### PR TITLE
Fix handles color not being reset to original color

### DIFF
--- a/Scripts/Editor/NodeEditorGUI.cs
+++ b/Scripts/Editor/NodeEditorGUI.cs
@@ -142,6 +142,7 @@ namespace XNodeEditor {
             for (int i = 0; i < gridPoints.Count; ++i)
                 gridPoints[i] = GridToWindowPosition(gridPoints[i]);
 
+            Color originalHandlesColor = Handles.color;
             Handles.color = gradient.Evaluate(0f);
             int length = gridPoints.Count;
             switch (path) {
@@ -305,6 +306,7 @@ namespace XNodeEditor {
                     gridPoints[length - 1] = end;
                     break;
             }
+            Handles.color = originalHandlesColor;
         }
 
         /// <summary> Draws all connections </summary>


### PR DESCRIPTION
The selection box shows a different color based on what noodle has been drawn last. This is because the Handles.color value doesn't get reset to its original value.

This PR is just a simple fix for that.