### PR TITLE
Fixed an issue with Undo / Redo not working correctly with Odin Prope…

### DIFF
--- a/Scripts/Editor/NodeEditor.cs
+++ b/Scripts/Editor/NodeEditor.cs
@@ -39,10 +39,28 @@ namespace XNodeEditor {
             string[] excludes = { "m_Script", "graph", "position", "ports" };
 
 #if ODIN_INSPECTOR
-            InspectorUtilities.BeginDrawPropertyTree(objectTree, true);
-            GUIHelper.PushLabelWidth(84);
-            objectTree.Draw(true);
+            try
+            {
+#if ODIN_INSPECTOR_3
+                objectTree.BeginDraw( true );
+#else
+                InspectorUtilities.BeginDrawPropertyTree(objectTree, true);
+#endif
+            }
+            catch ( ArgumentNullException )
+            {
+                objectTree.EndDraw();
+                NodeEditor.DestroyEditor(this.target);
+                return;
+            }
+
+            GUIHelper.PushLabelWidth( 84 );
+            objectTree.Draw( true );
+#if ODIN_INSPECTOR_3
+            objectTree.EndDraw();
+#else
             InspectorUtilities.EndDrawPropertyTree(objectTree);
+#endif
             GUIHelper.PopLabelWidth();
 #else
 

--- a/Scripts/Editor/NodeEditorBase.cs
+++ b/Scripts/Editor/NodeEditorBase.cs
@@ -24,7 +24,7 @@ namespace XNodeEditor.Internal {
 		private PropertyTree _objectTree;
 		public PropertyTree objectTree {
 			get {
-				if (this._objectTree == null) {
+                if (this._objectTree == null){
 					try {
 						bool wasInEditor = NodeEditor.inNodeEditor;
 						NodeEditor.inNodeEditor = true;
@@ -57,6 +57,16 @@ namespace XNodeEditor.Internal {
 			if (editor.serializedObject == null) editor.serializedObject = new SerializedObject(target);
 			return editor;
 		}
+
+        public static void DestroyEditor( K target )
+        {
+            if ( target == null ) return;
+            T editor;
+            if ( editors.TryGetValue( target, out editor ) )
+            {
+                editors.Remove( target );
+            }
+        }
 
 		private static Type GetEditorType(Type type) {
 			if (type == null) return null;


### PR DESCRIPTION
Fixed an issue with Odin undo / redo not functioning correctly. There is no nice way to determine the editor has been broken so I created a DestroyEditor that allows an editor to forcible be removed and re-created.

Also includes a slight update to remove warnings for Odin 3.x