### PR TITLE
[FIX] Copy & Paste in node's TextField

### DIFF
--- a/Scripts/Editor/NodeEditorAction.cs
+++ b/Scripts/Editor/NodeEditorAction.cs
@@ -337,11 +337,15 @@ namespace XNodeEditor {
                         if (e.type == EventType.ExecuteCommand) DuplicateSelectedNodes();
                         e.Use();
                     } else if (e.commandName == "Copy") {
-                        if (e.type == EventType.ExecuteCommand) CopySelectedNodes();
-                        e.Use();
+                        if (!EditorGUIUtility.editingTextField) {
+                            if (e.type == EventType.ExecuteCommand) CopySelectedNodes();
+                            e.Use();
+                        }
                     } else if (e.commandName == "Paste") {
-                        if (e.type == EventType.ExecuteCommand) PasteNodes(WindowToGridPosition(lastMousePosition));
-                        e.Use();
+                        if (!EditorGUIUtility.editingTextField) {
+                            if (e.type == EventType.ExecuteCommand) PasteNodes(WindowToGridPosition(lastMousePosition));
+                            e.Use();
+                        }
                     }
                     Repaint();
                     break;


### PR DESCRIPTION
Copy & Paste in node's TextField is broken. Try to fix it.