### PR TITLE
Fix issue for older Odin version

### DIFF
--- a/Scripts/Editor/NodeEditor.cs
+++ b/Scripts/Editor/NodeEditor.cs
@@ -49,7 +49,11 @@ namespace XNodeEditor {
             }
             catch ( ArgumentNullException )
             {
+#if ODIN_INSPECTOR_3
                 objectTree.EndDraw();
+#else
+                InspectorUtilities.EndDrawPropertyTree(objectTree);
+#endif
                 NodeEditor.DestroyEditor(this.target);
                 return;
             }


### PR DESCRIPTION
Fix for older Odin version

`Library\PackageCache\com.github.siccity.xnode@75ee5d47ff\Scripts\Editor\NodeEditor.cs(52,28): error CS1061: 'PropertyTree' does not contain a definition for 'EndDraw' and no accessible extension method 'EndDraw' accepting a first argument of type 'PropertyTree' could be found (are you missing a using directive or an assembly reference?)`