### PR TITLE
Fix OnRemoveConnection from calling side

### DIFF
--- a/Scripts/NodePort.cs
+++ b/Scripts/NodePort.cs
@@ -296,12 +296,13 @@ namespace XNode {
                 for (int i = 0; i < port.connections.Count; i++) {
                     if (port.connections[i].Port == this) {
                         port.connections.RemoveAt(i);
+                        // Trigger OnRemoveConnection from this side port
+                        port.node.OnRemoveConnection(port);
                     }
                 }
             }
             // Trigger OnRemoveConnection
             node.OnRemoveConnection(this);
-            if (port != null && port.IsConnectedTo(this)) port.node.OnRemoveConnection(port);
         }
 
         /// <summary> Disconnect this port from another port </summary>


### PR DESCRIPTION
If we use the original:
if (port != null && port.IsConnectedTo(this)) port.node.OnRemoveConnection(port);
we going to have always wrong condition, about "IsConnectedTo(this)" and port.node.OnRemoveConnection(port) just won't be called, cause we already have disconnected ports. So we need to do it exactly at the moment of disconnection.