### PR TITLE
Fix DynamicPortList reordering operating on old data

### DIFF
--- a/Scripts/Editor/NodeEditorGUILayout.cs
+++ b/Scripts/Editor/NodeEditorGUILayout.cs
@@ -394,6 +394,7 @@ namespace XNodeEditor {
                 };
             list.onReorderCallback =
                 (ReorderableList rl) => {
+                    serializedObject.Update();
                     bool hasRect = false;
                     bool hasNewRect = false;
                     Rect rect = Rect.zero;


### PR DESCRIPTION
Issue #347

Dynamic Port Lists weren't reordering correctly.  Updating the serializedObject before reordering seems to have done the trick.