### PR TITLE
added cases to handle Copy and Rename for scenegraphs correctly

### DIFF
--- a/Scripts/Editor/NodeGraphEditor.cs
+++ b/Scripts/Editor/NodeGraphEditor.cs
@@ -221,7 +221,7 @@ namespace XNodeEditor {
             XNode.Node node = target.CopyNode(original);
             Undo.RegisterCreatedObjectUndo(node, "Duplicate Node");
             node.name = original.name;
-            AssetDatabase.AddObjectToAsset(node, target);
+            if (!string.IsNullOrEmpty(AssetDatabase.GetAssetPath(target))) AssetDatabase.AddObjectToAsset(node, target);
             if (NodeEditorPreferences.GetSettings().autoSave) AssetDatabase.SaveAssets();
             return node;
         }

--- a/Scripts/Editor/RenamePopup.cs
+++ b/Scripts/Editor/RenamePopup.cs
@@ -53,8 +53,10 @@ namespace XNodeEditor {
                 if (GUILayout.Button("Revert to default") || (e.isKey && e.keyCode == KeyCode.Return)) {
                     target.name = NodeEditorUtilities.NodeDefaultName(target.GetType());
                     NodeEditor.GetEditor((XNode.Node)target, NodeEditorWindow.current).OnRename();
-                    AssetDatabase.SetMainObject((target as XNode.Node).graph, AssetDatabase.GetAssetPath(target));
-                    AssetDatabase.ImportAsset(AssetDatabase.GetAssetPath(target));
+                    if (!string.IsNullOrEmpty(AssetDatabase.GetAssetPath(target))) {
+                        AssetDatabase.SetMainObject((target as XNode.Node).graph, AssetDatabase.GetAssetPath(target));
+                        AssetDatabase.ImportAsset(AssetDatabase.GetAssetPath(target));
+                    }
                     Close();
                     target.TriggerOnValidate();
                 }
@@ -64,8 +66,10 @@ namespace XNodeEditor {
                 if (GUILayout.Button("Apply") || (e.isKey && e.keyCode == KeyCode.Return)) {
                     target.name = input;
                     NodeEditor.GetEditor((XNode.Node)target, NodeEditorWindow.current).OnRename();
-                    AssetDatabase.SetMainObject((target as XNode.Node).graph, AssetDatabase.GetAssetPath(target));
-                    AssetDatabase.ImportAsset(AssetDatabase.GetAssetPath(target));
+                    if (!string.IsNullOrEmpty(AssetDatabase.GetAssetPath(target))) {
+                        AssetDatabase.SetMainObject((target as XNode.Node).graph, AssetDatabase.GetAssetPath(target));
+                        AssetDatabase.ImportAsset(AssetDatabase.GetAssetPath(target));
+                    }
                     Close();
                     target.TriggerOnValidate();
                 }


### PR DESCRIPTION
If renaming and/or copying node inside SceneGraph exception is thrown as graph is not asset. 
Handled same way as in CreateNode