### PR TITLE
Ability to override ValueType of a Port

### DIFF
--- a/Scripts/Attributes/PortTypeOverrideAttribute.cs
+++ b/Scripts/Attributes/PortTypeOverrideAttribute.cs
@@ -1,0 +1,12 @@
+using System;
+/// <summary> Overrides the ValueType of the Port, to have a ValueType different from the type of its serializable field </summary>
+/// <remarks> Especially useful in Dynamic Port Lists to create Value-Port Pairs with different type. </remarks>
+[AttributeUsage(AttributeTargets.Field)]
+public class PortTypeOverrideAttribute : Attribute {
+    public Type type;
+    /// <summary> Overrides the ValueType of the Port </summary>
+    /// <param name="type">ValueType of the Port</param>
+    public PortTypeOverrideAttribute(Type type) {
+        this.type = type;
+    }
+}

--- a/Scripts/Attributes/PortTypeOverrideAttribute.cs.meta
+++ b/Scripts/Attributes/PortTypeOverrideAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1410c1437e863ab4fac7a7428aaca35b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/NodePort.cs
+++ b/Scripts/NodePort.cs
@@ -79,6 +79,10 @@ namespace XNode {
                     _connectionType = (attribs[i] as Node.OutputAttribute).connectionType;
                     _typeConstraint = (attribs[i] as Node.OutputAttribute).typeConstraint;
                 }
+                // Override ValueType of the Port
+                if(attribs[i] is PortTypeOverrideAttribute) {
+                    ValueType = (attribs[i] as PortTypeOverrideAttribute).type;
+                }
             }
         }
 


### PR DESCRIPTION
Adds an Attribute [PortTypeOverride], so that it is possible for a Port to have a ValueType different from the type of its serializable field. Which is useful in Dynamic Port Lists to create Value-Port Pairs with different types.

For example: Select one of multiple float inputs according to a given string, by using a List\<string> with [PortTypeOverride(typeof(float))]
![SelectNode](https://github.com/Siccity/xNode/assets/46198159/62dc1050-4d4f-4aac-abef-4ea82cbe4540)