### PR TITLE
Fix index after GetConnection did modify the list of connections

### DIFF
--- a/Scripts/NodePort.cs
+++ b/Scripts/NodePort.cs
@@ -231,6 +231,7 @@ namespace XNode {
             for (int i = 0; i < connections.Count; i++) {
                 NodePort port = GetConnection(i);
                 if (port != null) result.Add(port);
+                else i--;
             }
             return result;
         }


### PR DESCRIPTION
`GetConnection` removes element from list of connections when it returns `null`. This decreases indices of elements further in the list. I chose to fix the index to preserve the order, but iterating connections backwards would also do the trick.