### PR TITLE
Add `swapping (boolean)` parameter to node's `OnCreateConnection()` and `OnRemoveConnection()`

### DIFF
--- a/Scripts/Attributes/NodeEnum.cs
+++ b/Scripts/Attributes/NodeEnum.cs
@@ -1,5 +1,7 @@
 ﻿using UnityEngine;
 
-/// <summary> Draw enums correctly within nodes. Without it, enums show up at the wrong positions. </summary>
-/// <remarks> Enums with this attribute are not detected by EditorGui.ChangeCheck due to waiting before executing </remarks>
-public class NodeEnumAttribute : PropertyAttribute { }
+namespace XNode {
+    /// <summary> Draw enums correctly within nodes. Without it, enums show up at the wrong positions. </summary>
+    /// <remarks> Enums with this attribute are not detected by EditorGui.ChangeCheck due to waiting before executing </remarks>
+    public class NodeEnumAttribute : PropertyAttribute { }
+}

--- a/Scripts/Attributes/PortTypeOverrideAttribute.cs
+++ b/Scripts/Attributes/PortTypeOverrideAttribute.cs
@@ -1,12 +1,17 @@
 using System;
-/// <summary> Overrides the ValueType of the Port, to have a ValueType different from the type of its serializable field </summary>
-/// <remarks> Especially useful in Dynamic Port Lists to create Value-Port Pairs with different type. </remarks>
-[AttributeUsage(AttributeTargets.Field)]
-public class PortTypeOverrideAttribute : Attribute {
-    public Type type;
-    /// <summary> Overrides the ValueType of the Port </summary>
-    /// <param name="type">ValueType of the Port</param>
-    public PortTypeOverrideAttribute(Type type) {
-        this.type = type;
+
+namespace XNode {
+    /// <summary> Overrides the ValueType of the Port, to have a ValueType different from the type of its serializable field </summary>
+    /// <remarks> Especially useful in Dynamic Port Lists to create Value-Port Pairs with different type. </remarks>
+    [AttributeUsage(AttributeTargets.Field)]
+    public class PortTypeOverrideAttribute : Attribute
+    {
+        public Type type;
+        /// <summary> Overrides the ValueType of the Port </summary>
+        /// <param name="type">ValueType of the Port</param>
+        public PortTypeOverrideAttribute(Type type)
+        {
+            this.type = type;
+        }
     }
 }

--- a/Scripts/Node.cs
+++ b/Scripts/Node.cs
@@ -250,12 +250,15 @@ namespace XNode {
 #endregion
 
         /// <summary> Called after a connection between two <see cref="NodePort"/>s is created </summary>
-        /// <param name="from">Output</param> <param name="to">Input</param>
-        public virtual void OnCreateConnection(NodePort from, NodePort to) { }
+        /// <param name="from">Output</param>
+        /// <param name="to">Input</param>
+        /// <param name="swapping">Creating while swapping or not?</param>
+        public virtual void OnCreateConnection(NodePort from, NodePort to, bool swapping) { }
 
         /// <summary> Called after a connection is removed from this port </summary>
         /// <param name="port">Output or Input</param>
-        public virtual void OnRemoveConnection(NodePort port) { }
+        /// <param name="swapping">Removing while swapping or not?</param>
+        public virtual void OnRemoveConnection(NodePort port, bool swapping) { }
 
         /// <summary> Disconnect everything from this node </summary>
         public void ClearConnections() {

--- a/Scripts/NodeDataCache.cs
+++ b/Scripts/NodeDataCache.cs
@@ -226,7 +226,7 @@ namespace XNode {
                 this.Clear();
 
                 if (keys.Count != values.Count)
-                    throw new System.Exception(string.Format("there are {0} keys and {1} values after deserialization. Make sure that both key and value types are serializable."));
+                    throw new System.Exception(string.Format("there are {0} keys and {1} values after deserialization. Make sure that both key and value types are serializable.", keys.Count, values.Count));
 
                 for (int i = 0; i < keys.Count; i++)
                     this.Add(keys[i], values[i]);

--- a/Scripts/NodeDataCache.cs
+++ b/Scripts/NodeDataCache.cs
@@ -149,7 +149,15 @@ namespace XNode {
                     case "Microsoft":
                         continue;
                     default:
-                        nodeTypes.AddRange(assembly.GetTypes().Where(t => !t.IsAbstract && baseType.IsAssignableFrom(t)).ToArray());
+                        try
+                        {
+                            nodeTypes.AddRange(assembly.GetTypes().Where(t => !t.IsAbstract && baseType.IsAssignableFrom(t)).ToArray());
+                        }
+                        catch (System.Exception ex)
+                        {
+                            Debug.LogError("Catched exception when building " + assemblyName + " caches");
+                            Debug.LogException(ex);
+                        }
                         break;
                 }
             }


### PR DESCRIPTION
- I've use it to avoid invalid data issues when swap nodes in my project.
- Also add try...catch to detect which assemblies can't be added to `NodeDataCache.nodeTypes`, and also use it to avoid `BuildCache()` loop breaking.