### PR TITLE
Fix CS0619 on Unity 6000.4+: EndNameEditAction obsolete

### DIFF
--- a/Scripts/Editor/NodeEditorUtilities.cs
+++ b/Scripts/Editor/NodeEditorUtilities.cs
@@ -265,7 +265,11 @@ namespace XNodeEditor {
 
         public static void CreateFromTemplate(string initialName, string templatePath) {
             ProjectWindowUtil.StartNameEditingIfProjectWindowExists(
+#if UNITY_6000_4_OR_NEWER
+                EntityId.None,
+#else
                 0,
+#endif
                 ScriptableObject.CreateInstance<DoCreateCodeFile>(),
                 initialName,
                 scriptIcon,
@@ -274,12 +278,21 @@ namespace XNodeEditor {
         }
 
         /// Inherits from EndNameAction, must override EndNameAction.Action
+#if UNITY_6000_4_OR_NEWER
+        public class DoCreateCodeFile : UnityEditor.ProjectWindowCallback.AssetCreationEndAction {
+            public override void Action(EntityId instanceId, string pathName, string resourceFile) {
+                Object o = CreateScript(pathName, resourceFile);
+                ProjectWindowUtil.ShowCreatedAsset(o);
+            }
+        }
+#else
         public class DoCreateCodeFile : UnityEditor.ProjectWindowCallback.EndNameEditAction {
             public override void Action(int instanceId, string pathName, string resourceFile) {
                 Object o = CreateScript(pathName, resourceFile);
                 ProjectWindowUtil.ShowCreatedAsset(o);
             }
         }
+#endif
 
         /// <summary>Creates Script from Template's path.</summary>
         internal static UnityEngine.Object CreateScript(string pathName, string templatePath) {

--- a/Scripts/Editor/NodeEditorWindow.cs
+++ b/Scripts/Editor/NodeEditorWindow.cs
@@ -187,7 +187,11 @@ namespace XNodeEditor {
 
         [OnOpenAsset(0)]
         public static bool OnOpen(int instanceID, int line) {
+#if UNITY_6000_4_OR_NEWER
+            XNode.NodeGraph nodeGraph = EditorUtility.EntityIdToObject(instanceID) as XNode.NodeGraph;
+#else
             XNode.NodeGraph nodeGraph = EditorUtility.InstanceIDToObject(instanceID) as XNode.NodeGraph;
+#endif
             if (nodeGraph != null) {
                 Open(nodeGraph);
                 return true;


### PR DESCRIPTION
On Unity **6000.4+**, `UnityEditor.ProjectWindowCallback.EndNameEditAction` is marked obsolete **as an error**, so `NodeEditorUtilities.DoCreateCodeFile` no longer compiles:

```
error CS0619: 'EndNameEditAction' is obsolete: 'EndNameEditAction is obsolete. Use AssetCreationEndAction that uses EntityId instead of int for instance IDs.'
```

This migrates `DoCreateCodeFile` to `AssetCreationEndAction` with an `EntityId`-based `Action` override, and passes `EntityId.None` to `StartNameEditingIfProjectWindowExists`. Both changes are guarded by `#if UNITY_6000_4_OR_NEWER`, so older Unity versions keep the original `int`-based API unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
